### PR TITLE
refactor(Empty state): promote composition

### DIFF
--- a/src/components/empty_state/empty_state.rs
+++ b/src/components/empty_state/empty_state.rs
@@ -46,7 +46,7 @@ pub struct EmptyStateProperties {
 
     /** Cause component to consume the available height of its container */
     #[prop_or_default]
-    pub is_full_height: bool,
+    pub full_height: bool,
 }
 
 #[function_component(EmptyState)]
@@ -55,7 +55,7 @@ pub fn empty_state(props: &EmptyStateProperties) -> Html {
         <div
             class={classes!(
                 EmptyStateStyles::EMPTY_STATE,
-                props.variant.classes(props.is_full_height).to_string(),
+                props.variant.classes(props.full_height).to_string(),
                 &props.class,
             )}
         >

--- a/src/components/empty_state/empty_state.rs
+++ b/src/components/empty_state/empty_state.rs
@@ -1,0 +1,71 @@
+use crate::components::empty_state::styles::*;
+use std::fmt::Debug;
+
+use yew::prelude::*;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum EmptyStateVariant {
+    XS,
+    SM,
+    LG,
+    XL,
+    FULL,
+}
+
+impl EmptyStateVariant {
+    pub fn classes(&self, full_height: bool) -> &str {
+        return match self {
+            Self::XS => EmptyStateStyles::MODIFIERS_XS,
+            Self::SM => EmptyStateStyles::MODIFIERS_SM,
+            Self::LG => EmptyStateStyles::MODIFIERS_LG,
+            Self::XL => EmptyStateStyles::MODIFIERS_XL,
+            Self::FULL => {
+                if full_height {
+                    EmptyStateStyles::MODIFIERS_FULL_HEIGHT
+                } else {
+                    ""
+                }
+            }
+        };
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Properties)]
+pub struct EmptyStateProperties {
+    /** Content rendered inside the empty state */
+    #[prop_or_default]
+    pub children: Children,
+
+    /** Additional classes added to the empty state */
+    #[prop_or_default]
+    pub class: String,
+
+    /** Modifies empty state max-width and sizes of icon, title and body */
+    #[prop_or(EmptyStateVariant::FULL)]
+    pub variant: EmptyStateVariant,
+
+    /** Cause component to consume the available height of its container */
+    #[prop_or_default]
+    pub is_full_height: bool,
+}
+
+#[function_component(EmptyState)]
+pub fn empty_state(props: &EmptyStateProperties) -> Html {
+    html! (
+        <div
+            class={classes!(
+                EmptyStateStyles::EMPTY_STATE,
+                props.variant.classes(props.is_full_height).to_string(),
+                &props.class,
+            )}
+        >
+            <div
+                class={classes!(
+                    EmptyStateStyles::EMPTY_STATE_CONTENT,
+                )}
+            >
+                { for props.children.iter() }
+            </div>
+        </div>
+    )
+}

--- a/src/components/empty_state/empty_state_actions.rs
+++ b/src/components/empty_state/empty_state_actions.rs
@@ -1,0 +1,29 @@
+use crate::components::empty_state::styles::*;
+use std::fmt::Debug;
+
+use yew::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Properties)]
+pub struct EmptyStateActionsProperties {
+    /** Content rendered inside the empty state actions */
+    #[prop_or_default]
+    pub children: Children,
+
+    /** Additional classes added to the empty state actions */
+    #[prop_or_default]
+    pub class: String,
+}
+
+#[function_component(EmptyStateActions)]
+pub fn empty_state_actions(props: &EmptyStateActionsProperties) -> Html {
+    html! (
+        <div
+            class={classes!(
+                EmptyStateStyles::EMPTY_STATE_ACTIONS,
+                &props.class,
+            )}
+        >
+            { for props.children.iter() }
+        </div>
+    )
+}

--- a/src/components/empty_state/empty_state_body.rs
+++ b/src/components/empty_state/empty_state_body.rs
@@ -1,0 +1,29 @@
+use crate::components::empty_state::styles::*;
+use std::fmt::Debug;
+
+use yew::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Properties)]
+pub struct EmptyStateBodyProperties {
+    /** Content rendered inside the empty state body */
+    #[prop_or_default]
+    pub children: Children,
+
+    /** Additional classes added to the empty state body */
+    #[prop_or_default]
+    pub class: String,
+}
+
+#[function_component(EmptyStateBody)]
+pub fn empty_state_body(props: &EmptyStateBodyProperties) -> Html {
+    html! (
+        <div
+            class={classes!(
+                EmptyStateStyles::EMPTY_STATE_BODY,
+                &props.class,
+            )}
+        >
+            { for props.children.iter() }
+        </div>
+    )
+}

--- a/src/components/empty_state/empty_state_footer.rs
+++ b/src/components/empty_state/empty_state_footer.rs
@@ -1,0 +1,29 @@
+use crate::components::empty_state::styles::*;
+use std::fmt::Debug;
+
+use yew::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Properties)]
+pub struct EmptyStateFooterProperties {
+    /** Content rendered inside the empty state footer */
+    #[prop_or_default]
+    pub children: Children,
+
+    /** Additional classes added to the empty state footer */
+    #[prop_or_default]
+    pub class: String,
+}
+
+#[function_component(EmptyStateFooter)]
+pub fn empty_state_footer(props: &EmptyStateFooterProperties) -> Html {
+    html! (
+        <div
+            class={classes!(
+                EmptyStateStyles::EMPTY_STATE_FOOTER,
+                &props.class,
+            )}
+        >
+            { for props.children.iter() }
+        </div>
+    )
+}

--- a/src/components/empty_state/empty_state_header.rs
+++ b/src/components/empty_state/empty_state_header.rs
@@ -1,0 +1,81 @@
+use crate::components::empty_state::styles::*;
+use std::fmt::Debug;
+use yew::prelude::*;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum EmptyStateHeadingLevel {
+    H1,
+    H2,
+    H3,
+    H4,
+    H5,
+    H6,
+}
+
+impl EmptyStateHeadingLevel {
+    pub fn level(&self) -> &str {
+        return match self {
+            Self::H1 => "h1",
+            Self::H2 => "h2",
+            Self::H3 => "h3",
+            Self::H4 => "h4",
+            Self::H5 => "h5",
+            Self::H6 => "h6",
+        };
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Properties)]
+pub struct EmptyStateHeaderProperties {
+    /** Content rendered inside the empty state header, either in addition to or instead of the titleText prop */
+    #[prop_or_default]
+    pub children: Children,
+
+    /** Additional classes added to the empty state header */
+    #[prop_or_default]
+    pub class: String,
+
+    /** Additional classes added to the title inside empty state header */
+    #[prop_or_default]
+    pub title_class: String,
+
+    /** Text of the title inside empty state header, will be wrapped in headingLevel */
+    #[prop_or_default]
+    // pub title_text: Html,
+    pub title_text: Children,
+
+    /** Empty state icon element to be rendered */
+    #[prop_or_default]
+    pub icon: Children,
+
+    /** The heading level to use, default is h1 */
+    #[prop_or(EmptyStateHeadingLevel::H1)]
+    pub heading_level: EmptyStateHeadingLevel,
+}
+
+#[function_component(EmptyStateHeader)]
+pub fn empty_state_header(props: &EmptyStateHeaderProperties) -> Html {
+    html! (
+        <div
+            class={classes!(
+                EmptyStateStyles::EMPTY_STATE_HEADER,
+                &props.class,
+            )}
+        >
+            { for props.icon.iter() }
+            <div
+                class={classes!(EmptyStateStyles::EMPTY_STATE_TITLE)}
+            >
+                <@{props.heading_level.level().to_string()}
+                    class={classes!(
+                        EmptyStateStyles::EMPTY_STATE_TITLE_TEXT,
+                        &props.title_class
+                    )}
+                >
+                    { for props.title_text.iter() }
+                </@>
+                { for props.children.iter() }
+            </div>
+        </div>
+    )
+}

--- a/src/components/empty_state/empty_state_icon.rs
+++ b/src/components/empty_state/empty_state_icon.rs
@@ -1,0 +1,50 @@
+use crate::components::empty_state::styles::*;
+use std::fmt::Debug;
+
+use yew::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Properties)]
+pub struct EmptyStateIconProperties {
+    /** Additional classes added to the empty state icon */
+    #[prop_or_default]
+    pub class: AttrValue,
+
+    /** Adds an accessible name for the Table */
+    #[prop_or_default]
+    pub icon: Children,
+
+    /** Changes the color of the icon.  */
+    #[prop_or_default]
+    pub color: String,
+}
+
+#[function_component(EmptyStateIcon)]
+pub fn empty_state_icon(props: &EmptyStateIconProperties) -> Html {
+    let icon = props.icon.iter().map(|mut vnode| {
+        if let yew::virtual_dom::VNode::VTag(tag) = &mut vnode {
+            tag.add_attribute("class", props.class.clone());
+            tag.add_attribute("aria-hidden", "true");
+        }
+        vnode
+    });
+
+    let style = classes!(conditional!(
+        !props.color.is_empty(),
+        format!(
+            "{}: {};",
+            EmptyStateStyles::VARIABLE_C_EMPTY_STATE_ICON_COLOR,
+            props.color
+        )
+    ));
+
+    html! (
+        <div
+            class={classes!(
+                EmptyStateStyles::EMPTY_STATE_ICON,
+            )}
+            {style}
+        >
+            { for icon }
+        </div>
+    )
+}

--- a/src/components/empty_state/mod.rs
+++ b/src/components/empty_state/mod.rs
@@ -1,0 +1,15 @@
+pub mod empty_state;
+pub mod empty_state_actions;
+pub mod empty_state_body;
+pub mod empty_state_footer;
+pub mod empty_state_header;
+pub mod empty_state_icon;
+pub mod styles;
+
+pub use empty_state::*;
+pub use empty_state_actions::*;
+pub use empty_state_body::*;
+pub use empty_state_footer::*;
+pub use empty_state_header::*;
+pub use empty_state_icon::*;
+pub use styles::*;

--- a/src/components/empty_state/styles/empty_state.rs
+++ b/src/components/empty_state/styles/empty_state.rs
@@ -1,0 +1,22 @@
+#[non_exhaustive]
+pub struct EmptyStateStyles;
+
+impl EmptyStateStyles {
+    pub const EMPTY_STATE: &str = "pf-v5-c-empty-state";
+    pub const EMPTY_STATE_ACTIONS: &str = "pf-v5-c-empty-state__actions";
+    pub const EMPTY_STATE_BODY: &str = "pf-v5-c-empty-state__body";
+    pub const EMPTY_STATE_CONTENT: &str = "pf-v5-c-empty-state__content";
+    pub const EMPTY_STATE_FOOTER: &str = "pf-v5-c-empty-state__footer";
+    pub const EMPTY_STATE_ICON: &str = "pf-v5-c-empty-state__icon";
+    pub const EMPTY_STATE_TITLE: &str = "pf-v5-c-empty-state__title";
+    pub const EMPTY_STATE_TITLE_TEXT: &str = "pf-v5-c-empty-state__title-text";
+    pub const EMPTY_STATE_HEADER: &str = "pf-v5-c-empty-state__header";
+
+    pub const MODIFIERS_XS: &str = "pf-m-xs";
+    pub const MODIFIERS_SM: &str = "pf-m-sm";
+    pub const MODIFIERS_LG: &str = "pf-m-lg";
+    pub const MODIFIERS_XL: &str = "pf-m-xl";
+    pub const MODIFIERS_FULL_HEIGHT: &str = "pf-m-full-height";
+    
+    pub const VARIABLE_C_EMPTY_STATE_ICON_COLOR: &str = "--pf-v5-c-empty-state__icon--Color";
+}

--- a/src/components/empty_state/styles/mod.rs
+++ b/src/components/empty_state/styles/mod.rs
@@ -1,0 +1,3 @@
+mod empty_state;
+
+pub use empty_state::*;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -20,7 +20,7 @@ pub mod context_selector;
 pub mod divider;
 pub mod dl;
 pub mod dropdown;
-pub mod empty;
+pub mod empty_state;
 pub mod expandable_section;
 pub mod file_upload;
 pub mod form;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@
 
 #![recursion_limit = "1024"]
 mod icon;
+
+#[macro_use]
+pub mod macros;
+
 mod integration;
 
 pub mod components;

--- a/src/macros/conditional.rs
+++ b/src/macros/conditional.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! conditional {
+    ($condition: expr, $result: expr) => {{
+        if $condition {
+            Some($result)
+        } else {
+            None
+        }
+    }};
+}

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+mod conditional;
+
+pub use conditional::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,7 +25,7 @@ pub use crate::components::context_selector::*;
 pub use crate::components::divider::*;
 pub use crate::components::dl::*;
 pub use crate::components::dropdown::*;
-pub use crate::components::empty::*;
+pub use crate::components::empty_state::*;
 pub use crate::components::expandable_section::*;
 pub use crate::components::file_upload::*;
 pub use crate::components::form::*;


### PR DESCRIPTION
## Current limitations

The current implementation of `EmptyState` as of today allow us to define the component as:
```rust
<EmptyState
  title="Empty state"
  icon={Icon::Cubes}
  primary={Action::new("Push me", ctx.link().callback(|_|{}))}
  secondaries={vec![
       Action::new("Try me", ctx.link().callback(|_|{})),
       Action::new("Me too", ctx.link().callback(|_|{})),
       Action::new("Here, here", ctx.link().callback(|_|{})),
  ]}
  >
      {"This section should explain why the state is empty, and what you can do next."}
</EmptyState>
```

Here are some disadvantages I consider we currently face:
- The title can only be a `String`. While it works for some scenarios, it does not work when the user wants to customize it.
- The `icon` property is a type of `Option<Icon>` which forces the user to only be able to choose between the current set of Icons. If the user wants to use a custom image (.png, .svg, etc.) then the `EmptyState` does not fit that scenario.
- The property `pub primary: Option<Action>` encapsulates the primary button in a way that the user has no way of customizing the Primary Button. The property `pub primary: Option<Action>` is always attached to the `onclick` event of the button, but what if the user wants to do something on the `onsubmit` event? ... in short words, the user has no way of customizing the primary button other than the text and the event `onclick` which might be good enough for some scenarios but certainly not enough for other scenarios.
- The property `secondaries` has the same limitations as the `primary` field, it does not allow customization of the HTML elements.

## Promote composition

- The components should allow the user as much customization as possible, and then users can create their own set of components on top of the ones we provide in this repository. This is certainly the approach that Patternfly ReactJS does as a result continuous feedback and usage of that library.

This PR creates different components that users can later use and compose their own components on top of this. Users will define the `EmptyState` in the following way:

```rust
<EmptyState>
    <EmptyStateHeader
        title_text={html!("Empty state")}
        heading_level={EmptyStateHeadingLevel::H4}
        icon={html!(
            <EmptyStateIcon icon={html!(<>{Icon::Cubes}</>)} />
        )}
    />
    <EmptyStateBody>
        {"This represents the empty state pattern in PatternFly. Hopefully it's simple enough to use but flexible enough to meet a variety of needs."}
    </EmptyStateBody>
    <EmptyStateFooter>
        <EmptyStateActions>
            <Button variant={ButtonVariant::Primary}>{"Primary action"}</Button>
        </EmptyStateActions>
        <EmptyStateActions>
            <Button variant={ButtonVariant::Link}>{"Multiple"}</Button>
            <Button variant={ButtonVariant::Link}>{"Action Buttons"}</Button>
            <Button variant={ButtonVariant::Link}>{"Can"}</Button>
            <Button variant={ButtonVariant::Link}>{"Go here"}</Button>
            <Button variant={ButtonVariant::Link}>{"In the secondary"}</Button>
            <Button variant={ButtonVariant::Link}>{"Action area"}</Button>
        </EmptyStateActions>
    </EmptyStateFooter>
</EmptyState>
```

Advantages of the new approach based on composition:

- The `title` can be anything and not only a `String`
- The user can set anything in the ICON location. Users can use their own images or icons
- The user has full control over the button used for the primary and secondary actions; those buttons are not encapsulated any more.

## Consequences

-  This PR completely rewrites the `EmptyState` component and it might bring issues for any previous application that was using it. What do you think about the new approach? Should we keep the old component?
