### PR TITLE
Sorting table: Allow controlled and uncontrolled sorting status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4"
 yew = "0.20"
 yew-hooks = "0.2"
-yew-nested-router = { version = "0.2.0", optional = true }
+yew-nested-router = { version = "0.3.0", optional = true }
 
 web-sys = { version = "0.3", features = [
     "HtmlCollection",

--- a/src/components/table/column.rs
+++ b/src/components/table/column.rs
@@ -25,6 +25,10 @@ where
     #[prop_or_default]
     pub(crate) first_tree_column: bool,
 
+    // Current sortby status
+    #[prop_or_default]
+    pub sortby: Option<TableHeaderSortBy<C>>,
+
     #[prop_or_default]
     pub onsort: Option<Callback<TableHeaderSortBy<C>>>,
 }
@@ -103,7 +107,15 @@ where
                 let header_context = table_header_context.expect(
                     "Column must be inside TableHeader, the expected context is defined there",
                 );
-                let sort_by_next_status = match header_context.sortby {
+
+                // If status of sort is not provided by user then use the context
+                let sortby = if props.sortby.is_some() {
+                    &props.sortby
+                } else {
+                    &header_context.sortby
+                };
+
+                let sort_by_next_status = match sortby {
                     Some(val) => {
                         if val.index == props.index {
                             class.push(classes!("pf-m-selected"));
@@ -129,17 +141,19 @@ where
                         class="pf-v5-c-table__button"
                         onclick={
                             {
-                                let on_sort_by = header_context.onsort.clone();
+                                // Emit sorting in context and in user callback
+                                let onsort_context = header_context.onsort.clone();
+                                let onsort = onsort.clone();
+
                                 let index = props.index.clone();
                                 let asc = sort_by_next_status.1;
-                                let onsort = onsort.clone();
 
                                 Callback::from(move |_| {
                                     let sort_by = TableHeaderSortBy {
                                         index: index.clone(),
                                         asc: !asc
                                     };
-                                    on_sort_by.emit(Some(sort_by.clone()));
+                                    onsort_context.emit(sort_by.clone());
                                     onsort.emit(sort_by.clone());
                                 })
                             }

--- a/src/components/table/header.rs
+++ b/src/components/table/header.rs
@@ -2,7 +2,7 @@ use super::column::TableColumn;
 use std::fmt::Debug;
 use yew::prelude::*;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Copy)]
 pub struct TableHeaderSortBy<K>
 where
     K: Clone + Eq + 'static,
@@ -17,7 +17,7 @@ where
     K: Clone + Eq + 'static,
 {
     pub sortby: Option<TableHeaderSortBy<K>>,
-    pub onsort: Callback<Option<TableHeaderSortBy<K>>>,
+    pub onsort: Callback<TableHeaderSortBy<K>>,
 }
 
 /// Properties for [`TableHeader`]
@@ -48,8 +48,8 @@ where
 {
     let sortby: UseStateHandle<Option<TableHeaderSortBy<K>>> = use_state_eq(|| None);
     let onsort = use_callback(
-        |val: Option<TableHeaderSortBy<K>>, sortby| {
-            sortby.set(val);
+        |val: TableHeaderSortBy<K>, sortby| {
+            sortby.set(Some(val));
         },
         sortby.clone(),
     );

--- a/src/components/table/mod.rs
+++ b/src/components/table/mod.rs
@@ -65,6 +65,77 @@ where
     }
 }
 
+/// Table component
+///
+/// > A **table** is used to display large data sets that can be easily laid out in a simple grid with column headers.
+///
+/// See: <https://www.patternfly.org/components/table/html>
+///
+/// ## Properties
+///
+/// Defined by [`TableProperties`].
+///
+/// ## Usage
+///
+/// The table component is a more complex component than most others. It is recommended to check
+/// out the more complete examples in the quickstart project: <https://github.com/patternfly-yew/patternfly-yew-quickstart/tree/main/src/components/table>.
+///
+/// Summarizing it, you will need:
+///
+/// * A type defining the column/index (this can be an enum or a numeric like `usize`).
+/// * A type defining an item/entry/row.
+/// * Let the item type implement [`TableEntryRenderer`].
+/// * Create a table state model (e.g. using [`MemoizedTableModel`]).
+/// * Wire up the table state model (e.g. using [`use_table_data`]).
+///
+/// ## Example
+///
+/// ```rust
+/// use yew::prelude::*;
+/// use patternfly_yew::prelude::*;
+///
+/// #[derive(Copy, Clone, Eq, PartialEq)]
+/// enum Column { First, Second };
+/// struct ExampleEntry { foo: String };
+///
+/// impl TableEntryRenderer<Column> for ExampleEntry {
+///   fn render_cell(&self, context: CellContext<'_, Column>) -> Cell {
+///     match context.column {
+///       Column::First => html!(&self.foo).into(),
+///       Column::Second => html!({self.foo.len()}).into(),
+///     }
+///   }
+/// }
+///
+/// #[function_component(Example)]
+/// fn example() -> Html {
+///
+///   let entries = use_memo(|()| {
+///       vec![
+///           ExampleEntry { foo: "bar".into() },
+///           ExampleEntry {
+///               foo: "Much, much longer foo".into(),
+///           },
+///       ]
+///   }, ());
+///
+///   let (entries, _) = use_table_data(MemoizedTableModel::new(entries));
+///
+///   let header = html_nested! {
+///     <TableHeader<Column>>
+///       <TableColumn<Column> label="foo" index={Column::First} />
+///       <TableColumn<Column> label="bar" index={Column::Second} />
+///     </TableHeader<Column>>
+///  };
+///
+///   html! (
+///     <Table<Column, UseTableData<Column, MemoizedTableModel<ExampleEntry>>>
+///       {header}
+///       {entries}
+///     />
+///   )
+/// }
+/// ```
 #[function_component(Table)]
 pub fn table<C, M>(props: &TableProperties<C, M>) -> Html
 where


### PR DESCRIPTION
Inspired by https://github.com/patternfly-yew/patternfly-yew/compare/main...carlosthe19916:sorting-controlled?expand=1

- If use does not set the status of the current sorting then the context header takes care of saving the status
- If user do set the status of the current sorting then this status is used

This is useful on scenarios where the table needs to be re-rendered, in this scenario the internal Context is lost therefore is advised the user to manage the status