### PR TITLE
Added a class prop to the Stack layout struct

### DIFF
--- a/src/layouts/stack.rs
+++ b/src/layouts/stack.rs
@@ -8,6 +8,8 @@ pub struct StackProperties {
     pub children: Children,
     #[prop_or_default]
     pub gutter: bool,
+    #[prop_or_default]
+    pub class: Classes,
 }
 
 /// Stack layout
@@ -31,6 +33,8 @@ pub fn stack(props: &StackProperties) -> Html {
     if props.gutter {
         classes.push("pf-m-gutter");
     }
+
+    classes.extend(props.class.clone());
 
     html! (
         <div class={classes}>


### PR DESCRIPTION
I wanted to be able to access the props on the div contained by the Stack component. I copied the pattern used for the card component and did something similar to the Stack layout component.