### PR TITLE
fix: Expandable cells table show empty header column

### DIFF
--- a/src/components/table/mod.rs
+++ b/src/components/table/mod.rs
@@ -63,6 +63,18 @@ where
             TableMode::Expandable | TableMode::CompactExpandable
         )
     }
+
+    pub fn are_columns_expandable(&self) -> bool {
+        if let Some(header) = &self.header {
+            header
+                .props
+                .children
+                .iter()
+                .any(|table_column| table_column.props.expandable)
+        } else {
+            false
+        }
+    }
 }
 
 /// Table component
@@ -217,7 +229,7 @@ where
     C: Clone + Eq + 'static,
     M: PartialEq + TableModel<C> + 'static,
 {
-    let expandable = props.is_expandable();
+    let expandable = props.is_expandable() && !props.are_columns_expandable();
     match &props.header {
         Some(header) => {
             let mut header = header.clone();


### PR DESCRIPTION
If the table wants to render expandable columns, then the current table adds an empty column to the header. That behavior was added for the use case of "extended content table" where the arrow in the first column is added. However, when expanded content is applied to cells, then there is no need for empty columns in the header
 
![Screenshot from 2023-10-16 15-09-15](https://github.com/patternfly-yew/patternfly-yew/assets/2582866/e257a5d6-4c4e-4776-ab5d-53b267688aeb)
