### PR TITLE
hotfix menu items not full width

### DIFF
--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -77,6 +77,48 @@ pub fn drop_down(props: &DropdownProperties) -> Html {
     let onclose = use_callback(expanded.clone(), |(), expanded| expanded.set(false));
     let context = CloseMenuContext::new(onclose);
 
+    let mut style = state.styles.popper.extend_with("z-index", "1000");
+    if props.full_width {
+        if let Some(elem) = inside_ref.cast::<web_sys::HtmlElement>() {
+            style = style.extend_with("width", format!("{}px", elem.offset_width()));
+        }
+    }
+    // let style = use_state(|| style);
+
+    // let modifier = {
+    //     let inside_ref = inside_ref.clone();
+    //     let state = state.clone();
+    //     let full_width = props.full_width;
+    //     let style = style.clone();
+    //     ModifierFn(std::rc::Rc::new(wasm_bindgen::prelude::Closure::new(
+    //         move |_: popper_rs::sys::ModifierArguments| {
+    //             if full_width {
+    //                 if let Some(elem) = inside_ref.cast::<web_sys::HtmlElement>() {
+    //                     assert!(false);
+    //                     let new_style = state
+    //                         .styles
+    //                         .popper
+    //                         .extend_with("z-index", "1000")
+    //                         .extend_with("width", format!("{}px", elem.offset_width()));
+    //                     style.set(new_style);
+    //                 }
+    //             }
+    //         },
+    //     )))
+    // };
+
+    // let modifiers = if props.full_width {
+    //     assert!(false);
+    //     Vec::from([Modifier::Custom {
+    //         name: "widthMods".into(),
+    //         phase: Some("beforeWrite".into()),
+    //         enabled: Some(props.full_width),
+    //         r#fn: Some(modifier)
+    //     }])
+    // } else {
+    //     Vec::new()
+    // };
+
     html!(
         <>
             <div style="display: inline;" ref={inside_ref}>
@@ -86,13 +128,14 @@ pub fn drop_down(props: &DropdownProperties) -> Html {
                     visible={*expanded}
                     {onstatechange}
                     {placement}
+                    // modifiers={modifiers}
                 >
                     <ContextProvider<CloseMenuContext>
                         {context}
                     >
                         <Menu
                             r#ref={menu_ref}
-                            style={&state.styles.popper.extend_with("z-index", "1000")}
+                            style={&style}
                         >
                             { props.children.clone() }
                         </Menu>


### PR DESCRIPTION
I made a mistake on the last PR because the popper for the items isn't resized along with the dropdown.

This is still a draft because it isn't responsive. You need to close and reopen the dropdown for the correct size to display for the items.

I have some commented lines where I attempted to make it responsive. However, as soon as I have a `UseStateHandle` for the style being passed to the `Menu`, the item are rendered above the dropdown and have the full width of the window.

Will look into it more tomorrow.