### PR TITLE
Implement dual list selector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,9 @@ router = ["yew-nested-router"]
 # things which go away any minute
 legacy = []
 
-experimental = ["tree"]
+experimental = ["tree", "dual_list_selector"]
 tree = []
+dual_list_selector = []
 
 # Enable FontAwesome regular (FAR) and/or brand (FAB) icons, remember to import the font in your application
 icons-far = []

--- a/src/components/button/mod.rs
+++ b/src/components/button/mod.rs
@@ -125,6 +125,9 @@ pub struct ButtonProperties {
 
     #[prop_or_default]
     pub children: Html,
+
+    #[prop_or_default]
+    pub tabindex: Option<isize>,
 }
 
 /// Button component
@@ -195,6 +198,7 @@ pub fn button(props: &ButtonProperties) -> Html {
             onclick.emit(evt);
         })
     };
+    let tabindex: Option<AttrValue> = props.tabindex.map(|i| i.to_string().into());
 
     html! (
          <button
@@ -213,6 +217,7 @@ pub fn button(props: &ButtonProperties) -> Html {
             aria-haspopup={&props.aria_haspopup}
             aria-expanded={&props.aria_expanded}
             aria-controls={&props.aria_controls}
+            {tabindex}
          >
              if props.loading {
                  <span class="pf-v5-c-button__progress">

--- a/src/components/dual_list_selector/control/button.rs
+++ b/src/components/dual_list_selector/control/button.rs
@@ -37,7 +37,7 @@ pub fn control(props: &DualListSelectorControlProps) -> Html {
         <Button
             disabled={props.disabled}
             variant={ButtonVariant::Plain}
-            // TODO tabindex=-1
+            tabindex={Some(-1)}
             onclick={props.onclick.clone()}
         >
             { props.children.clone() }

--- a/src/components/dual_list_selector/control/button.rs
+++ b/src/components/dual_list_selector/control/button.rs
@@ -1,8 +1,11 @@
 //! The DualListSelectorControl component.
 
-use crate::components::{
-    button::{Button, ButtonVariant},
-    tooltip::Tooltip,
+use crate::{
+    components::{
+        button::{Button, ButtonVariant},
+        tooltip::Tooltip,
+    },
+    prelude::TooltipProperties,
 };
 use yew::prelude::*;
 
@@ -18,10 +21,10 @@ pub struct DualListSelectorControlProps {
     #[prop_or_default]
     pub tooltip: Option<AttrValue>,
 
-    // TODO
-    // /// Additional tooltip properties passed to the tooltip.
-    // #[prop_or_default]
-    // tooltip_props: anymap2::AnyMap,
+    /// Additional tooltip properties passed to the tooltip.
+    #[prop_or_default]
+    pub tooltip_props: Option<TooltipProperties>,
+
     /// Flag indicating the control is disabled.
     #[prop_or(true)]
     pub disabled: bool,
@@ -49,9 +52,15 @@ pub fn control(props: &DualListSelectorControlProps) -> Html {
     };
     let inner = if let Some(text) = &props.tooltip {
         html! {
-            <Tooltip text={text.to_string()}>
-                { button }
-            </Tooltip>
+            if let Some(props) = &props.tooltip_props {
+                <Tooltip text={text.to_string()} ..props.clone()>
+                    { button }
+                </Tooltip>
+            } else {
+                <Tooltip text={text.to_string()}>
+                    { button }
+                </Tooltip>
+            }
         }
     } else {
         button

--- a/src/components/dual_list_selector/control/button.rs
+++ b/src/components/dual_list_selector/control/button.rs
@@ -10,6 +10,10 @@ use yew::prelude::*;
 /// dual list selector pane.
 #[derive(Debug, Clone, PartialEq, Properties)]
 pub struct DualListSelectorControlProps {
+    /// Additional classes applied to the dual list selector control.
+    #[prop_or_default]
+    pub class: Classes,
+
     /// Content to be displayed in a tooltip on hover of control.
     #[prop_or_default]
     pub tooltip: Option<AttrValue>,
@@ -53,7 +57,7 @@ pub fn control(props: &DualListSelectorControlProps) -> Html {
         button
     };
     html! {
-        <div class="pf-v5-c-dual-list-selector__controls-item">
+        <div class={classes!["pf-v5-c-dual-list-selector__controls-item", props.class.clone()]}>
             { inner }
         </div>
     }

--- a/src/components/dual_list_selector/control/button.rs
+++ b/src/components/dual_list_selector/control/button.rs
@@ -1,0 +1,60 @@
+//! The DualListSelectorControl component.
+
+use crate::components::{
+    button::{Button, ButtonVariant},
+    tooltip::Tooltip,
+};
+use yew::prelude::*;
+
+/// Renders an individual control button for moving selected options between each
+/// dual list selector pane.
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct DualListSelectorControlProps {
+    /// Content to be displayed in a tooltip on hover of control.
+    #[prop_or_default]
+    pub tooltip: Option<AttrValue>,
+
+    // TODO
+    // /// Additional tooltip properties passed to the tooltip.
+    // #[prop_or_default]
+    // tooltip_props: anymap2::AnyMap,
+    /// Flag indicating the control is disabled.
+    #[prop_or(true)]
+    pub disabled: bool,
+
+    /// Content to be rendered in the dual list selector control.
+    #[prop_or_default]
+    pub children: Html,
+
+    /// Callback fired when dual list selector control is selected.
+    #[prop_or_default]
+    pub onclick: Callback<MouseEvent>,
+}
+
+#[function_component(DualListSelectorControl)]
+pub fn control(props: &DualListSelectorControlProps) -> Html {
+    let button = html! {
+        <Button
+            disabled={props.disabled}
+            variant={ButtonVariant::Plain}
+            // TODO tabindex=-1
+            onclick={props.onclick.clone()}
+        >
+            { props.children.clone() }
+        </Button>
+    };
+    let inner = if let Some(text) = &props.tooltip {
+        html! {
+            <Tooltip text={text.to_string()}>
+                { button }
+            </Tooltip>
+        }
+    } else {
+        button
+    };
+    html! {
+        <div class="pf-v5-c-dual-list-selector__controls-item">
+            { inner }
+        </div>
+    }
+}

--- a/src/components/dual_list_selector/control/mod.rs
+++ b/src/components/dual_list_selector/control/mod.rs
@@ -1,0 +1,7 @@
+//! Components related to dual list selector controls.
+
+mod button;
+mod wrapper;
+
+pub use button::*;
+pub use wrapper::*;

--- a/src/components/dual_list_selector/control/wrapper.rs
+++ b/src/components/dual_list_selector/control/wrapper.rs
@@ -1,0 +1,20 @@
+//! The DualListSelectorControlsWrapper component
+
+use yew::prelude::*;
+
+/// Acts as the container for the DualListSelectorControl sub-components.
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct DualListSelectorControlsWrapperProps {
+    /// Anything that can be rendered inside of the wrapper.
+    pub children: Html,
+}
+
+#[function_component(DualListSelectorControlsWrapper)]
+pub fn wrapper(props: &DualListSelectorControlsWrapperProps) -> Html {
+    // TODO key handling
+    html! {
+        <div class="pf-v5-c-dual-list-selector__controls" tabindex=0 role="group">
+            { props.children.clone() }
+        </div>
+    }
+}

--- a/src/components/dual_list_selector/control/wrapper.rs
+++ b/src/components/dual_list_selector/control/wrapper.rs
@@ -7,13 +7,18 @@ use yew::prelude::*;
 pub struct DualListSelectorControlsWrapperProps {
     /// Anything that can be rendered inside of the wrapper.
     pub children: Html,
+
+    /// Additional classes added to the wrapper.
+    #[prop_or_default]
+    pub class: Classes,
 }
 
 #[function_component(DualListSelectorControlsWrapper)]
 pub fn wrapper(props: &DualListSelectorControlsWrapperProps) -> Html {
     // TODO key handling
+    let class = classes!["pf-v5-c-dual-list-selector__controls", props.class.clone()];
     html! {
-        <div class="pf-v5-c-dual-list-selector__controls" tabindex=0 role="group">
+        <div {class} tabindex=0 role="group">
             { props.children.clone() }
         </div>
     }

--- a/src/components/dual_list_selector/item_renderer.rs
+++ b/src/components/dual_list_selector/item_renderer.rs
@@ -1,0 +1,9 @@
+//! Trait for rendering an item in a DualListSelector component.
+
+use core::fmt::Debug;
+
+use yew::prelude::*;
+
+pub trait DualListSelectorItemRenderer: Debug + Clone + PartialEq + ToHtml + 'static {}
+
+impl<T: ToHtml + Debug + Clone + PartialEq + 'static> DualListSelectorItemRenderer for T {}

--- a/src/components/dual_list_selector/list/item.rs
+++ b/src/components/dual_list_selector/list/item.rs
@@ -5,6 +5,10 @@ use yew::prelude::*;
 /// This is contained within the DualListSelectorList sub-component.
 #[derive(Debug, Clone, PartialEq, Properties)]
 pub struct DualListSelectorItemProps {
+    /// Additional classes applied to the dual list selector.
+    #[prop_or_default]
+    pub class: Classes,
+
     /// Flag indicating the list item is currently selected.
     #[prop_or_default]
     pub is_selected: bool,
@@ -22,7 +26,7 @@ pub struct DualListSelectorItemProps {
 
 #[function_component(DualListSelectorListItem)]
 pub fn list_item(props: &DualListSelectorItemProps) -> Html {
-    let mut row_class = classes!["pf-v5-c-dual-list-selector__list-item-row"];
+    let mut row_class = classes!["pf-v5-c-dual-list-selector__list-item-row", props.class.clone()];
     if props.is_selected {
         row_class.push("pf-m-selected");
     }

--- a/src/components/dual_list_selector/list/item.rs
+++ b/src/components/dual_list_selector/list/item.rs
@@ -31,7 +31,7 @@ pub fn list_item(props: &DualListSelectorItemProps) -> Html {
         item_class.push("pf-m-disabled")
     }
     html! {
-        <li class={item_class} onclick={props.onoptionselect.clone()} tabindex={-1}>
+        <li class={item_class} onclick={props.onoptionselect.clone()} tabindex="-1">
             <div class={row_class}>
                 <span class="pf-v5-c-dual-list-selector__item">
                     <span class="pf-v5-c-dual-list-selector__item-main">

--- a/src/components/dual_list_selector/list/item.rs
+++ b/src/components/dual_list_selector/list/item.rs
@@ -1,0 +1,46 @@
+/// The DualListSelectorItem component
+use yew::prelude::*;
+
+/// Creates an individual option that can be selected and moved between the dual list selector panes.
+/// This is contained within the DualListSelectorList sub-component.
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct DualListSelectorItemProps {
+    /// Flag indicating the list item is currently selected.
+    #[prop_or_default]
+    pub is_selected: bool,
+
+    /// Callback fired when an option is selected.
+    pub onoptionselect: Callback<MouseEvent>,
+
+    /// Content rendered inside the dual list selector.
+    pub children: Html,
+
+    /// Flag indicating if the dual list selector is in a disabled state.
+    #[prop_or_default]
+    pub disabled: bool,
+}
+
+#[function_component(DualListSelectorListItem)]
+pub fn list_item(props: &DualListSelectorItemProps) -> Html {
+    let mut row_class = classes!["pf-v5-c-dual-list-selector__list-item-row"];
+    if props.is_selected {
+        row_class.push("pf-m-selected");
+    }
+    let mut item_class = classes!["pf-v5-c-dual-list-selector__list-item"];
+    if props.disabled {
+        item_class.push("pf-m-disabled")
+    }
+    html! {
+        <li class={item_class} onclick={props.onoptionselect.clone()} tabindex={-1}>
+            <div class={row_class}>
+                <span class="pf-v5-c-dual-list-selector__item">
+                    <span class="pf-v5-c-dual-list-selector__item-main">
+                        <span class="pf-v5-c-dual-list-selector__item-text">
+                            { props.children.clone() }
+                        </span>
+                    </span>
+                </span>
+            </div>
+        </li>
+    }
+}

--- a/src/components/dual_list_selector/list/item.rs
+++ b/src/components/dual_list_selector/list/item.rs
@@ -26,7 +26,10 @@ pub struct DualListSelectorItemProps {
 
 #[function_component(DualListSelectorListItem)]
 pub fn list_item(props: &DualListSelectorItemProps) -> Html {
-    let mut row_class = classes!["pf-v5-c-dual-list-selector__list-item-row", props.class.clone()];
+    let mut row_class = classes![
+        "pf-v5-c-dual-list-selector__list-item-row",
+        props.class.clone()
+    ];
     if props.is_selected {
         row_class.push("pf-m-selected");
     }

--- a/src/components/dual_list_selector/list/list_inner.rs
+++ b/src/components/dual_list_selector/list/list_inner.rs
@@ -3,8 +3,9 @@
 use yew::prelude::*;
 
 use super::{
-    super::DualListSelectorItemRenderer as ItemRenderer, DualListSelectorListContext as Context,
-    DualListSelectorListItem,
+    super::DualListSelectorItemRenderer as ItemRenderer,
+    super::{OnOptionSelectArgsNoChosen, OnOptionSelectEvent},
+    DualListSelectorListContext as Context, DualListSelectorListItem,
 };
 
 /// Acts as the container for DualListSelectorListItem sub-components.
@@ -26,7 +27,14 @@ pub fn list<T: ItemRenderer>(props: &DualListSelectorListProps) -> Html {
                 { for context.options.iter().enumerate().map(|(key, option)| {
                     let onoptionselect = {
                         let onoptionselect = context.onoptionselect.clone();
-                        Callback::from(move |e| onoptionselect.emit((e, key)))
+                        Callback::from(move |e: MouseEvent| {
+                            let e: OnOptionSelectEvent = e.into();
+                            let args = OnOptionSelectArgsNoChosen {
+                                event: e,
+                                index: key,
+                            };
+                            onoptionselect.emit(args)
+                        })
                     };
                     let is_selected = context.selected_options.contains(&key);
                     html_nested! {

--- a/src/components/dual_list_selector/list/list_inner.rs
+++ b/src/components/dual_list_selector/list/list_inner.rs
@@ -1,0 +1,41 @@
+//! The DualListSelectorList component.
+
+use yew::prelude::*;
+
+use super::{
+    super::DualListSelectorItemRenderer as ItemRenderer, DualListSelectorListContext as Context,
+    DualListSelectorListItem,
+};
+
+/// Acts as the container for DualListSelectorListItem sub-components.
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct DualListSelectorListProps {
+    /// Content rendered inside the dual list selector list.
+    #[prop_or_default]
+    pub children: Html,
+}
+
+#[function_component(DualListSelectorList)]
+pub fn list<T: ItemRenderer>(props: &DualListSelectorListProps) -> Html {
+    let context = use_context::<Context<T>>().unwrap();
+    html! {
+        <ul class="pf-v5-c-dual-list-selector__list">
+            if context.options.is_empty() {
+                { props.children.clone() }
+            } else {
+                { for context.options.iter().enumerate().map(|(key, option)| {
+                    let onoptionselect = {
+                        let onoptionselect = context.onoptionselect.clone();
+                        Callback::from(move |e| onoptionselect.emit((e, key)))
+                    };
+                    let is_selected = context.selected_options.contains(&key);
+                    html_nested! {
+                        <DualListSelectorListItem key={key} {onoptionselect} {is_selected} disabled={context.disabled}>
+                            { option.to_html() }
+                        </DualListSelectorListItem>
+                    }
+                })}
+            }
+        </ul>
+    }
+}

--- a/src/components/dual_list_selector/list/mod.rs
+++ b/src/components/dual_list_selector/list/mod.rs
@@ -1,0 +1,9 @@
+//! Components related to dual list selector's list inside a pane.
+
+mod item;
+mod list_inner;
+mod wrapper;
+
+pub use item::*;
+pub use list_inner::*;
+pub use wrapper::*;

--- a/src/components/dual_list_selector/list/wrapper.rs
+++ b/src/components/dual_list_selector/list/wrapper.rs
@@ -2,6 +2,8 @@
 
 use yew::prelude::*;
 
+use crate::components::dual_list_selector::OnOptionSelectArgsNoChosen;
+
 use super::{super::DualListSelectorItemRenderer as ItemRenderer, DualListSelectorList};
 
 #[derive(Debug, Clone, PartialEq, Properties)]
@@ -19,7 +21,7 @@ pub struct DualListSelectorListWrapperProps<T: ItemRenderer> {
     pub selected_options: Vec<usize>,
 
     /// Callback for when an option is selected. Optionally used only when options prop is provided.
-    pub onoptionselect: Callback<(MouseEvent, usize)>,
+    pub onoptionselect: Callback<OnOptionSelectArgsNoChosen>,
 
     /// Flag indicating whether the component is disabled.
     #[prop_or_default]
@@ -34,7 +36,7 @@ pub struct DualListSelectorListWrapperProps<T: ItemRenderer> {
 pub struct DualListSelectorListContext<T: ItemRenderer> {
     pub options: Vec<T>,
     pub selected_options: Vec<usize>,
-    pub onoptionselect: Callback<(MouseEvent, usize)>,
+    pub onoptionselect: Callback<OnOptionSelectArgsNoChosen>,
     pub disabled: bool,
 }
 

--- a/src/components/dual_list_selector/list/wrapper.rs
+++ b/src/components/dual_list_selector/list/wrapper.rs
@@ -6,6 +6,10 @@ use super::{super::DualListSelectorItemRenderer as ItemRenderer, DualListSelecto
 
 #[derive(Debug, Clone, PartialEq, Properties)]
 pub struct DualListSelectorListWrapperProps<T: ItemRenderer> {
+    /// Additional classes applied to the dual list selector.
+    #[prop_or_default]
+    pub class: Classes,
+
     /// Options to list in the pane.
     #[prop_or_default]
     pub options: Vec<T>,
@@ -43,7 +47,7 @@ pub fn wrapper<T: ItemRenderer>(props: &DualListSelectorListWrapperProps<T>) -> 
         disabled: props.disabled,
     };
     html! {
-        <div class={classes!["pf-v5-c-dual-list-selector__menu"]} tabindex=0>
+        <div class={classes!["pf-v5-c-dual-list-selector__menu", props.class.clone()]} tabindex=0>
             <ContextProvider<DualListSelectorListContext<T>> {context}>
                 if !props.children.is_empty() {
                     { props.children.clone() }

--- a/src/components/dual_list_selector/list/wrapper.rs
+++ b/src/components/dual_list_selector/list/wrapper.rs
@@ -1,0 +1,56 @@
+//! The DualListSelcotrListWrapper component.
+
+use yew::prelude::*;
+
+use super::{super::DualListSelectorItemRenderer as ItemRenderer, DualListSelectorList};
+
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct DualListSelectorListWrapperProps<T: ItemRenderer> {
+    /// Options to list in the pane.
+    #[prop_or_default]
+    pub options: Vec<T>,
+
+    /// Options currently selected in the pane.
+    #[prop_or_default]
+    pub selected_options: Vec<usize>,
+
+    /// Callback for when an option is selected. Optionally used only when options prop is provided.
+    pub onoptionselect: Callback<(MouseEvent, usize)>,
+
+    /// Flag indicating whether the component is disabled.
+    #[prop_or_default]
+    pub disabled: bool,
+
+    /// Anything that can be rendered inside of the list.
+    #[prop_or_default]
+    pub children: Children,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DualListSelectorListContext<T: ItemRenderer> {
+    pub options: Vec<T>,
+    pub selected_options: Vec<usize>,
+    pub onoptionselect: Callback<(MouseEvent, usize)>,
+    pub disabled: bool,
+}
+
+#[function_component(DualListSelectorListWrapper)]
+pub fn wrapper<T: ItemRenderer>(props: &DualListSelectorListWrapperProps<T>) -> Html {
+    let context = DualListSelectorListContext {
+        options: props.options.clone(),
+        selected_options: props.selected_options.clone(),
+        onoptionselect: props.onoptionselect.clone(),
+        disabled: props.disabled,
+    };
+    html! {
+        <div class={classes!["pf-v5-c-dual-list-selector__menu"]} tabindex=0>
+            <ContextProvider<DualListSelectorListContext<T>> {context}>
+                if !props.children.is_empty() {
+                    { props.children.clone() }
+                } else {
+                    <DualListSelectorList<T>/>
+                }
+            </ContextProvider<DualListSelectorListContext<T>>>
+        </div>
+    }
+}

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -1,6 +1,6 @@
 //! The dynamic and composable [dual list selector](https://www.patternfly.org/components/dual-list-selector)
 
-use crate::icon::Icon;
+use crate::{components::tooltip::TooltipProperties, icon::Icon};
 use yew::prelude::*;
 
 mod control;
@@ -45,15 +45,27 @@ pub struct DualListSelectorProps<T: DualListSelectorItemRenderer> {
     /// Tooltip content for the dynamically built add selected button.
     #[prop_or_default]
     pub add_selected_tooltip: Option<AttrValue>,
+    /// Additonal tooltip properties to the dynamically built add selected tooltip.
+    #[prop_or_default]
+    pub add_selected_tooltip_props: Option<TooltipProperties>,
     /// Tooltip content for the dynamically built add all button.
     #[prop_or_default]
     pub add_all_available_tooltip: Option<AttrValue>,
+    /// Additonal tooltip properties to the dynamically built add all tooltip.
+    #[prop_or_default]
+    pub add_all_available_tooltip_props: Option<TooltipProperties>,
     /// Tooltip content for the dynamically built remove selected button.
     #[prop_or_default]
     pub remove_selected_tooltip: Option<AttrValue>,
+    /// Additonal tooltip properties to the dynamically built remove selected tooltip.
+    #[prop_or_default]
+    pub remove_selected_tooltip_props: Option<TooltipProperties>,
     /// Tooltip content for the dynamically built remove all button.
     #[prop_or_default]
     pub remove_all_chosen_tooltip: Option<AttrValue>,
+    /// Additonal tooltip properties to the dynamically built remove selected tooltip.
+    #[prop_or_default]
+    pub remove_all_chosen_tooltip_props: Option<TooltipProperties>,
 
     /// Callback fired every time dynamically built options are chosen or removed.
     /// Inputs are the mouse event as well as the available and chosen options after the change.
@@ -239,6 +251,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     tooltip={props.add_selected_tooltip.clone()}
                     disabled={props.disabled}
                     onclick={control_option(State::add_selected)}
+                    tooltip_props={props.add_selected_tooltip_props.clone()}
                 >
                     // TODO: This seems to be off-center but it's rendered correctly when
                     //  serving the SVG, do we have it somewhere?
@@ -248,6 +261,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     tooltip={props.add_all_available_tooltip.clone()}
                     disabled={props.disabled}
                     onclick={control_option(State::add_all_visible)}
+                    tooltip_props={props.add_all_available_tooltip_props.clone()}
                 >
                     { Icon::AngleDoubleRight.as_html() }
                 </DualListSelectorControl>
@@ -255,6 +269,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     tooltip={props.remove_all_chosen_tooltip.clone()}
                     disabled={props.disabled}
                     onclick={control_option(State::remove_all_visible)}
+                    tooltip_props={props.remove_all_chosen_tooltip_props.clone()}
                 >
                     { Icon::AngleDoubleLeft.as_html() }
                 </DualListSelectorControl>
@@ -262,6 +277,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     tooltip={props.remove_selected_tooltip.clone()}
                     disabled={props.disabled}
                     onclick={control_option(State::remove_selected)}
+                    tooltip_props={props.remove_selected_tooltip_props.clone()}
                 >
                     // TODO: This seems to be off-center but it's rendered correctly when
                     //  serving the SVG, do we have it somewhere?

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -1,0 +1,282 @@
+//! The dynamic and composable [dual list selector](https://www.patternfly.org/components/dual-list-selector)
+
+use crate::icon::Icon;
+use yew::prelude::*;
+
+mod control;
+mod item_renderer;
+mod list;
+mod pane;
+
+pub use control::*;
+pub use item_renderer::*;
+pub use list::*;
+pub use pane::*;
+
+/// Acts as a container for all other DualListSelector sub-components when using a
+/// composable dual list selector.
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct DualListSelectorProps<T: DualListSelectorItemRenderer> {
+    /// Title applied to the dynamically built available options pane.
+    #[prop_or_default]
+    pub available_options_title: Option<AttrValue>,
+
+    /// Status message to display above the dynamically built available options pane.
+    #[prop_or_default]
+    pub available_options_status: Option<AttrValue>,
+    /// Options to display in the dynamically built available options pane.
+    #[prop_or_default]
+    pub available: Vec<T>,
+
+    /// Title applied to the dynamically built chosen options pane.
+    #[prop_or_default]
+    pub chosen_options_title: Option<AttrValue>,
+    /// Status message to display above the dynamically built chosen options pane.
+    #[prop_or_default]
+    pub chosen_options_status: Option<AttrValue>,
+    /// Options to display in the dynamically built chosen options pane.
+    #[prop_or_default]
+    pub chosen: Vec<T>,
+
+    /// Tooltip content for the dynamically built add selected button.
+    #[prop_or_default]
+    pub add_selected_tooltip: Option<AttrValue>,
+    /// Tooltip content for the dynamically built add all button.
+    #[prop_or_default]
+    pub add_all_available_tooltip: Option<AttrValue>,
+    /// Tooltip content for the dynamically built remove selected button.
+    #[prop_or_default]
+    pub remove_selected_tooltip: Option<AttrValue>,
+    /// Tooltip content for the dynamically built remove all button.
+    #[prop_or_default]
+    pub remove_all_chosen_tooltip: Option<AttrValue>,
+
+    /// Callback fired every time dynamically built options are chosen or removed.
+    /// Inputs are the mouse event as well as the available and chosen options after the change.
+    #[prop_or_default]
+    pub onlistchange: Option<Callback<(MouseEvent, Vec<T>, Vec<T>)>>,
+
+    /// Flag indicating if the dual list selector is in a disabled state
+    #[prop_or_default]
+    pub disabled: bool,
+
+    /// Content to be rendered in the dual list selector. Panes & controls will not be built dynamically when children are provided.
+    #[prop_or_default]
+    pub children: Children,
+}
+
+/// The state of the dual list selector.
+/// Saves which options exist and which of those are selected
+/// for the "available" and "chosen" panels.
+///
+/// The selected vectors save the indices of the selected items
+/// of the options vectors.
+#[derive(Debug, Clone)]
+struct State<T: DualListSelectorItemRenderer> {
+    onlistchange: Option<Callback<(MouseEvent, Vec<T>, Vec<T>)>>,
+    available_options: Vec<T>,
+    available_options_selected: Vec<usize>,
+    chosen_options: Vec<T>,
+    chosen_options_selected: Vec<usize>,
+}
+
+impl<T: DualListSelectorItemRenderer> State<T> {
+    pub fn toggle_chosen_option(&mut self, index: usize) {
+        Self::toggle_option(&mut self.chosen_options_selected, index);
+    }
+
+    pub fn toggle_available_option(&mut self, index: usize) {
+        Self::toggle_option(&mut self.available_options_selected, index);
+    }
+
+    pub fn add_all_visible(&mut self, e: MouseEvent) {
+        Self::move_all(
+            &mut self.available_options_selected,
+            &mut self.available_options,
+            &mut self.chosen_options,
+        );
+        self.emit_onlistchange(e)
+    }
+
+    pub fn add_selected(&mut self, e: MouseEvent) {
+        Self::move_selected(
+            &mut self.available_options_selected,
+            &mut self.available_options,
+            &mut self.chosen_options,
+        );
+        self.emit_onlistchange(e)
+    }
+
+    pub fn remove_selected(&mut self, e: MouseEvent) {
+        Self::move_selected(
+            &mut self.chosen_options_selected,
+            &mut self.chosen_options,
+            &mut self.available_options,
+        );
+        self.emit_onlistchange(e)
+    }
+
+    pub fn remove_all_visible(&mut self, e: MouseEvent) {
+        Self::move_all(
+            &mut self.chosen_options_selected,
+            &mut self.chosen_options,
+            &mut self.available_options,
+        );
+        self.emit_onlistchange(e)
+    }
+
+    fn move_all(src_selected: &mut Vec<usize>, src_options: &mut Vec<T>, dst_options: &mut Vec<T>) {
+        dst_options.extend_from_slice(src_options);
+        src_options.clear();
+        src_selected.clear();
+    }
+
+    fn move_selected(
+        src_selected: &mut Vec<usize>,
+        src_options: &mut Vec<T>,
+        dst_options: &mut Vec<T>,
+    ) {
+        let selected_html = src_selected
+            .iter()
+            .map(|&idx| src_options[idx].clone())
+            .collect::<Vec<T>>();
+        dst_options.extend_from_slice(&selected_html);
+        src_options.retain(|i| !selected_html.contains(i));
+        src_selected.clear();
+    }
+
+    fn toggle_option(v: &mut Vec<usize>, elem: usize) {
+        match v.iter().position(|&x| x == elem) {
+            // Remove from selected
+            Some(i) => {
+                v.remove(i);
+            }
+            // Add to selected
+            None => v.push(elem),
+        }
+    }
+
+    fn emit_onlistchange(&self, e: MouseEvent) {
+        if let Some(f) = &self.onlistchange {
+            f.emit((
+                e,
+                self.available_options.clone(),
+                self.chosen_options.clone(),
+            ))
+        }
+    }
+}
+
+#[function_component(DualListSelector)]
+pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
+    props: &DualListSelectorProps<T>,
+) -> Html {
+    let state = use_state(|| State {
+        onlistchange: props.onlistchange.clone(),
+        available_options: props.available.clone(),
+        available_options_selected: Vec::new(),
+        chosen_options: props.chosen.clone(),
+        chosen_options_selected: Vec::new(),
+    });
+    let onoptionselect = {
+        let state = state.clone();
+        Callback::from(move |(_e, index, is_chosen)| {
+            let mut new_state = (*state).clone();
+            if is_chosen {
+                new_state.toggle_chosen_option(index);
+            } else {
+                new_state.toggle_available_option(index);
+            }
+            state.set(new_state);
+        })
+    };
+    let available_options_status = props.available_options_status.clone().unwrap_or_else(|| {
+        format!(
+            "{} of {} item selected",
+            state.available_options_selected.len(),
+            state.available_options.len()
+        )
+        .into()
+    });
+    let chosen_options_status = props.chosen_options_status.clone().unwrap_or_else(|| {
+        format!(
+            "{} of {} item selected",
+            state.chosen_options_selected.len(),
+            state.chosen_options.len()
+        )
+        .into()
+    });
+    let control_option = |f: fn(&mut State<T>, MouseEvent)| {
+        let state = state.clone();
+        Callback::from(move |e| {
+            let mut new_state = (*state).clone();
+            f(&mut new_state, e);
+            state.set(new_state);
+        })
+    };
+    html! {
+      <div class="pf-v5-c-dual-list-selector">
+        if !props.children.is_empty() {
+            { props.children.clone() }
+        } else {
+            <DualListSelectorPane<T>
+                title={props.available_options_title.clone()}
+                status={available_options_status}
+                options={state.available_options.clone()}
+                onoptionselect={
+                    let onoptionselect = onoptionselect.clone();
+                    Callback::from(move |(e, elem)| onoptionselect.emit((e, elem, false)))
+                }
+                selected_options={state.available_options_selected.clone()}
+                disabled={props.disabled}
+            />
+            <DualListSelectorControlsWrapper>
+                <DualListSelectorControl
+                    tooltip={props.add_selected_tooltip.clone()}
+                    disabled={props.disabled}
+                    onclick={control_option(State::add_selected)}
+                >
+                    // TODO: This seems to be off-center but it's rendered correctly when
+                    //  serving the SVG, do we have it somewhere?
+                    { Icon::AngleRight.as_html() }
+                </DualListSelectorControl>
+                <DualListSelectorControl
+                    tooltip={props.add_all_available_tooltip.clone()}
+                    disabled={props.disabled}
+                    onclick={control_option(State::add_all_visible)}
+                >
+                    { Icon::AngleDoubleRight.as_html() }
+                </DualListSelectorControl>
+                <DualListSelectorControl
+                    tooltip={props.remove_all_chosen_tooltip.clone()}
+                    disabled={props.disabled}
+                    onclick={control_option(State::remove_all_visible)}
+                >
+                    { Icon::AngleDoubleLeft.as_html() }
+                </DualListSelectorControl>
+                <DualListSelectorControl
+                    tooltip={props.remove_selected_tooltip.clone()}
+                    disabled={props.disabled}
+                    onclick={control_option(State::remove_selected)}
+                >
+                    // TODO: This seems to be off-center but it's rendered correctly when
+                    //  serving the SVG, do we have it somewhere?
+                    { Icon::AngleLeft.as_html() }
+                </DualListSelectorControl>
+            </DualListSelectorControlsWrapper>
+            <DualListSelectorPane<T>
+                is_chosen=true
+                title={props.chosen_options_title.clone()}
+                status={chosen_options_status}
+                options={state.chosen_options.clone()}
+                onoptionselect={
+                    let onoptionselect = onoptionselect.clone();
+                    Callback::from(move |(e, elem)| onoptionselect.emit((e, elem, true)))
+                }
+                selected_options={state.chosen_options_selected.clone()}
+                disabled={props.disabled}
+            />
+        }
+      </div>
+    }
+}

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -287,9 +287,9 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     onclick={control_option(State::add_selected)}
                     tooltip_props={props.add_selected_tooltip_props.clone()}
                 >
-                    // TODO: This seems to be off-center but it's rendered correctly when
-                    //  serving the SVG, do we have it somewhere?
-                    { Icon::AngleRight.as_html() }
+                    // This will be left-aligned instead of centered
+                    // View https://github.com/patternfly-yew/patternfly-yew/issues/83
+                    { Icon::AngleRight }
                 </DualListSelectorControl>
                 <DualListSelectorControl
                     tooltip={props.add_all_available_tooltip.clone()}
@@ -297,7 +297,9 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     onclick={control_option(State::add_all_visible)}
                     tooltip_props={props.add_all_available_tooltip_props.clone()}
                 >
-                    { Icon::AngleDoubleRight.as_html() }
+                    // This will be left-aligned instead of centered
+                    // View https://github.com/patternfly-yew/patternfly-yew/issues/83
+                    { Icon::AngleDoubleRight }
                 </DualListSelectorControl>
                 <DualListSelectorControl
                     tooltip={props.remove_all_chosen_tooltip.clone()}
@@ -305,7 +307,9 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     onclick={control_option(State::remove_all_visible)}
                     tooltip_props={props.remove_all_chosen_tooltip_props.clone()}
                 >
-                    { Icon::AngleDoubleLeft.as_html() }
+                    // This will be left-aligned instead of centered
+                    // View https://github.com/patternfly-yew/patternfly-yew/issues/83
+                    { Icon::AngleDoubleLeft }
                 </DualListSelectorControl>
                 <DualListSelectorControl
                     tooltip={props.remove_selected_tooltip.clone()}
@@ -313,9 +317,9 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     onclick={control_option(State::remove_selected)}
                     tooltip_props={props.remove_selected_tooltip_props.clone()}
                 >
-                    // TODO: This seems to be off-center but it's rendered correctly when
-                    //  serving the SVG, do we have it somewhere?
-                    { Icon::AngleLeft.as_html() }
+                    // This will be left-aligned instead of centered
+                    // View https://github.com/patternfly-yew/patternfly-yew/issues/83
+                    { Icon::AngleLeft }
                 </DualListSelectorControl>
             </DualListSelectorControlsWrapper>
             <DualListSelectorPane<T>

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -337,9 +337,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     onclick={control_option(State::add_selected)}
                     tooltip_props={props.add_selected_tooltip_props.clone()}
                 >
-                    // This will be left-aligned instead of centered
-                    // View https://github.com/patternfly-yew/patternfly-yew/issues/83
-                    { Icon::AngleRight }
+                    { Icon::AngleRight.with_style("width:1em;display:block;") }
                 </DualListSelectorControl>
                 <DualListSelectorControl
                     tooltip={props.add_all_available_tooltip.clone()}
@@ -347,9 +345,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     onclick={control_option(State::add_all_visible)}
                     tooltip_props={props.add_all_available_tooltip_props.clone()}
                 >
-                    // This will be left-aligned instead of centered
-                    // View https://github.com/patternfly-yew/patternfly-yew/issues/83
-                    { Icon::AngleDoubleRight }
+                    { Icon::AngleDoubleRight.with_style("width:1em;display:block;") }
                 </DualListSelectorControl>
                 <DualListSelectorControl
                     tooltip={props.remove_all_chosen_tooltip.clone()}
@@ -357,9 +353,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     onclick={control_option(State::remove_all_visible)}
                     tooltip_props={props.remove_all_chosen_tooltip_props.clone()}
                 >
-                    // This will be left-aligned instead of centered
-                    // View https://github.com/patternfly-yew/patternfly-yew/issues/83
-                    { Icon::AngleDoubleLeft }
+                    { Icon::AngleDoubleLeft.with_style("width:1em;display:block;") }
                 </DualListSelectorControl>
                 <DualListSelectorControl
                     tooltip={props.remove_selected_tooltip.clone()}
@@ -367,9 +361,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
                     onclick={control_option(State::remove_selected)}
                     tooltip_props={props.remove_selected_tooltip_props.clone()}
                 >
-                    // This will be left-aligned instead of centered
-                    // View https://github.com/patternfly-yew/patternfly-yew/issues/83
-                    { Icon::AngleLeft }
+                    { Icon::AngleLeft.with_style("width:1em;display:block;") }
                 </DualListSelectorControl>
             </DualListSelectorControlsWrapper>
             <DualListSelectorPane<T>

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -49,25 +49,25 @@ pub struct DualListSelectorProps<T: DualListSelectorItemRenderer> {
     /// Tooltip content for the dynamically built add selected button.
     #[prop_or_default]
     pub add_selected_tooltip: Option<AttrValue>,
-    /// Additonal tooltip properties to the dynamically built add selected tooltip.
+    /// Additional tooltip properties to the dynamically built add selected tooltip.
     #[prop_or_default]
     pub add_selected_tooltip_props: Option<TooltipProperties>,
     /// Tooltip content for the dynamically built add all button.
     #[prop_or_default]
     pub add_all_available_tooltip: Option<AttrValue>,
-    /// Additonal tooltip properties to the dynamically built add all tooltip.
+    /// Additional tooltip properties to the dynamically built add all tooltip.
     #[prop_or_default]
     pub add_all_available_tooltip_props: Option<TooltipProperties>,
     /// Tooltip content for the dynamically built remove selected button.
     #[prop_or_default]
     pub remove_selected_tooltip: Option<AttrValue>,
-    /// Additonal tooltip properties to the dynamically built remove selected tooltip.
+    /// Additional tooltip properties to the dynamically built remove selected tooltip.
     #[prop_or_default]
     pub remove_selected_tooltip_props: Option<TooltipProperties>,
     /// Tooltip content for the dynamically built remove all button.
     #[prop_or_default]
     pub remove_all_chosen_tooltip: Option<AttrValue>,
-    /// Additonal tooltip properties to the dynamically built remove selected tooltip.
+    /// Additional tooltip properties to the dynamically built remove selected tooltip.
     #[prop_or_default]
     pub remove_all_chosen_tooltip_props: Option<TooltipProperties>,
 

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -265,7 +265,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
     props: &DualListSelectorProps<T>,
 ) -> Html {
     let state = use_state(|| State {
-        add_selected: props.add_all.clone(),
+        add_selected: props.add_selected.clone(),
         add_all: props.add_all.clone(),
         remove_all: props.remove_all.clone(),
         remove_selected: props.remove_selected.clone(),

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -13,6 +13,10 @@ pub use item_renderer::*;
 pub use list::*;
 pub use pane::*;
 
+/// The inputs of the onlistchanged event. Has the corresponding mouse event of the
+/// button press, as well as the available and chosen options after the change.
+pub type DualListSelectorOnListChangedInputs<T> = (MouseEvent, Vec<T>, Vec<T>);
+
 /// Acts as a container for all other DualListSelector sub-components when using a
 /// composable dual list selector.
 #[derive(Debug, Clone, PartialEq, Properties)]
@@ -70,7 +74,7 @@ pub struct DualListSelectorProps<T: DualListSelectorItemRenderer> {
     /// Callback fired every time dynamically built options are chosen or removed.
     /// Inputs are the mouse event as well as the available and chosen options after the change.
     #[prop_or_default]
-    pub onlistchange: Option<Callback<(MouseEvent, Vec<T>, Vec<T>)>>,
+    pub onlistchange: Option<Callback<DualListSelectorOnListChangedInputs<T>>>,
 
     /// Flag indicating if the dual list selector is in a disabled state
     #[prop_or_default]
@@ -89,7 +93,7 @@ pub struct DualListSelectorProps<T: DualListSelectorItemRenderer> {
 /// of the options vectors.
 #[derive(Debug, Clone)]
 struct State<T: DualListSelectorItemRenderer> {
-    onlistchange: Option<Callback<(MouseEvent, Vec<T>, Vec<T>)>>,
+    onlistchange: Option<Callback<DualListSelectorOnListChangedInputs<T>>>,
     available_options: Vec<T>,
     available_options_selected: Vec<usize>,
     chosen_options: Vec<T>,

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -17,6 +17,10 @@ pub use pane::*;
 /// composable dual list selector.
 #[derive(Debug, Clone, PartialEq, Properties)]
 pub struct DualListSelectorProps<T: DualListSelectorItemRenderer> {
+    /// Additional classes applied to the dual list selector.
+    #[prop_or_default]
+    pub class: Classes,
+
     /// Title applied to the dynamically built available options pane.
     #[prop_or_default]
     pub available_options_title: Option<AttrValue>,
@@ -215,7 +219,7 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
         })
     };
     html! {
-      <div class="pf-v5-c-dual-list-selector">
+      <div class={classes!["pf-v5-c-dual-list-selector", props.class.clone()]}>
         if !props.children.is_empty() {
             { props.children.clone() }
         } else {

--- a/src/components/dual_list_selector/mod.rs
+++ b/src/components/dual_list_selector/mod.rs
@@ -52,24 +52,36 @@ pub struct DualListSelectorProps<T: DualListSelectorItemRenderer> {
     /// Additional tooltip properties to the dynamically built add selected tooltip.
     #[prop_or_default]
     pub add_selected_tooltip_props: Option<TooltipProperties>,
+    /// Optional callback for the dynamically built add selected button.
+    #[prop_or_default]
+    pub add_selected: Option<Callback<(Vec<T>, Vec<T>)>>,
     /// Tooltip content for the dynamically built add all button.
     #[prop_or_default]
     pub add_all_available_tooltip: Option<AttrValue>,
     /// Additional tooltip properties to the dynamically built add all tooltip.
     #[prop_or_default]
     pub add_all_available_tooltip_props: Option<TooltipProperties>,
+    /// Optional callback for the dynamically built add all button.
+    #[prop_or_default]
+    pub add_all: Option<Callback<(Vec<T>, Vec<T>)>>,
     /// Tooltip content for the dynamically built remove selected button.
     #[prop_or_default]
     pub remove_selected_tooltip: Option<AttrValue>,
     /// Additional tooltip properties to the dynamically built remove selected tooltip.
     #[prop_or_default]
     pub remove_selected_tooltip_props: Option<TooltipProperties>,
+    /// Optional callback for the dynamically built remove selected button.
+    #[prop_or_default]
+    pub remove_selected: Option<Callback<(Vec<T>, Vec<T>)>>,
     /// Tooltip content for the dynamically built remove all button.
     #[prop_or_default]
     pub remove_all_chosen_tooltip: Option<AttrValue>,
     /// Additional tooltip properties to the dynamically built remove selected tooltip.
     #[prop_or_default]
     pub remove_all_chosen_tooltip_props: Option<TooltipProperties>,
+    /// Optional callback for the dynamically built remove all button.
+    #[prop_or_default]
+    pub remove_all: Option<Callback<(Vec<T>, Vec<T>)>>,
 
     /// Callback fired every time dynamically built options are chosen or removed.
     /// Inputs are the mouse event as well as the available and chosen options after the change.
@@ -98,6 +110,10 @@ struct State<T: DualListSelectorItemRenderer> {
     available_options_selected: Vec<usize>,
     chosen_options: Vec<T>,
     chosen_options_selected: Vec<usize>,
+    add_selected: Option<Callback<(Vec<T>, Vec<T>)>>,
+    add_all: Option<Callback<(Vec<T>, Vec<T>)>>,
+    remove_all: Option<Callback<(Vec<T>, Vec<T>)>>,
+    remove_selected: Option<Callback<(Vec<T>, Vec<T>)>>,
 }
 
 impl<T: DualListSelectorItemRenderer> State<T> {
@@ -115,7 +131,8 @@ impl<T: DualListSelectorItemRenderer> State<T> {
             &mut self.available_options,
             &mut self.chosen_options,
         );
-        self.emit_onlistchange(e)
+        self.emit_onlistchange(e);
+        self.emit_callback(&self.add_all);
     }
 
     pub fn add_selected(&mut self, e: MouseEvent) {
@@ -124,7 +141,8 @@ impl<T: DualListSelectorItemRenderer> State<T> {
             &mut self.available_options,
             &mut self.chosen_options,
         );
-        self.emit_onlistchange(e)
+        self.emit_onlistchange(e);
+        self.emit_callback(&self.add_selected);
     }
 
     pub fn remove_selected(&mut self, e: MouseEvent) {
@@ -133,7 +151,8 @@ impl<T: DualListSelectorItemRenderer> State<T> {
             &mut self.chosen_options,
             &mut self.available_options,
         );
-        self.emit_onlistchange(e)
+        self.emit_onlistchange(e);
+        self.emit_callback(&self.remove_selected);
     }
 
     pub fn remove_all_visible(&mut self, e: MouseEvent) {
@@ -142,7 +161,8 @@ impl<T: DualListSelectorItemRenderer> State<T> {
             &mut self.chosen_options,
             &mut self.available_options,
         );
-        self.emit_onlistchange(e)
+        self.emit_onlistchange(e);
+        self.emit_callback(&self.remove_all);
     }
 
     fn move_all(src_selected: &mut Vec<usize>, src_options: &mut Vec<T>, dst_options: &mut Vec<T>) {
@@ -185,6 +205,12 @@ impl<T: DualListSelectorItemRenderer> State<T> {
             ))
         }
     }
+
+    fn emit_callback(&self, f: &Option<Callback<(Vec<T>, Vec<T>)>>) {
+        if let Some(f) = f {
+            f.emit((self.available_options.clone(), self.chosen_options.clone()));
+        }
+    }
 }
 
 #[function_component(DualListSelector)]
@@ -192,6 +218,10 @@ pub fn dual_list_selector<T: DualListSelectorItemRenderer>(
     props: &DualListSelectorProps<T>,
 ) -> Html {
     let state = use_state(|| State {
+        add_selected: props.add_all.clone(),
+        add_all: props.add_all.clone(),
+        remove_all: props.remove_all.clone(),
+        remove_selected: props.remove_selected.clone(),
         onlistchange: props.onlistchange.clone(),
         available_options: props.available.clone(),
         available_options_selected: Vec::new(),

--- a/src/components/dual_list_selector/pane.rs
+++ b/src/components/dual_list_selector/pane.rs
@@ -1,0 +1,87 @@
+//! The DualListSelectorPane component.
+
+use yew::prelude::*;
+
+use super::{DualListSelectorItemRenderer, DualListSelectorList, DualListSelectorListWrapper};
+
+/// Acts as the container for a list of options that are either available or chosen,
+/// depending on the pane type (available or chosen).
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct DualListSelectorPaneProps<T: DualListSelectorItemRenderer> {
+    /// Options to list in the pane.
+    #[prop_or_default]
+    pub options: Vec<T>,
+
+    /// Options currently selected in the pane.
+    #[prop_or_default]
+    pub selected_options: Vec<usize>,
+
+    /// Callback for when an option is selected. Optionally used only when options prop is provided.
+    pub onoptionselect: Callback<(MouseEvent, usize)>,
+
+    /// Title of the pane.
+    #[prop_or_default]
+    pub title: Option<AttrValue>,
+
+    /// Status to display above the pane.
+    #[prop_or_default]
+    pub status: Option<AttrValue>,
+
+    /// Flag indicating if this pane is the chosen pane.
+    #[prop_or_default]
+    pub is_chosen: bool,
+
+    /// Flag indicating whether the component is disabled.
+    #[prop_or_default]
+    pub disabled: bool,
+
+    /// A dual list selector list to be rendered in the pane.
+    #[prop_or_default]
+    pub children: ChildrenWithProps<DualListSelectorList<T>>,
+}
+
+#[function_component(DualListSelectorPane)]
+pub fn pane<T: DualListSelectorItemRenderer>(props: &DualListSelectorPaneProps<T>) -> Html {
+    let mut class = classes!["pf-v5-c-dual-list-selector__pane"];
+    if props.is_chosen {
+        class.push("pf-m-chosen")
+    } else {
+        class.push("pf-m-available")
+    }
+    let title = match &props.title {
+        None => html! {},
+        Some(title) => html! {
+            <div class={classes!["pf-v5-c-dual-list-selector__header"]}>
+                <div class={classes!["pf-v5-c-dual-list-selector__title"]}>
+                    <div class={classes!["pf-v5-c-dual-list-selector__title-text"]}>
+                        { title }
+                    </div>
+                </div>
+            </div>
+        },
+    };
+    let status = match &props.status {
+        None => html! {},
+        Some(status) => html! {
+            <div class="pf-v5-c-dual-list-selector__status">
+                <div class="pf-v5-c-dual-list-selector__status-text" id="dual-list-selector-basic-available-pane-status">
+                    { status }
+                </div>
+            </div>
+        },
+    };
+    html! {
+        <div {class}>
+            { title }
+            { status }
+            <DualListSelectorListWrapper<T>
+                options={props.options.clone()}
+                selected_options={props.selected_options.clone()}
+                onoptionselect={props.onoptionselect.clone()}
+                disabled={props.disabled}
+            >
+                { for props.children.iter() }
+            </DualListSelectorListWrapper<T>>
+        </div>
+    }
+}

--- a/src/components/dual_list_selector/pane.rs
+++ b/src/components/dual_list_selector/pane.rs
@@ -21,7 +21,7 @@ pub struct DualListSelectorPaneProps<T: DualListSelectorItemRenderer> {
     pub selected_options: Vec<usize>,
 
     /// Callback for when an option is selected. Optionally used only when options prop is provided.
-    pub onoptionselect: Callback<(MouseEvent, usize)>,
+    pub onoptionselect: Callback<super::OnOptionSelectArgsNoChosen>,
 
     /// Title of the pane.
     #[prop_or_default]

--- a/src/components/dual_list_selector/pane.rs
+++ b/src/components/dual_list_selector/pane.rs
@@ -8,6 +8,10 @@ use super::{DualListSelectorItemRenderer, DualListSelectorList, DualListSelector
 /// depending on the pane type (available or chosen).
 #[derive(Debug, Clone, PartialEq, Properties)]
 pub struct DualListSelectorPaneProps<T: DualListSelectorItemRenderer> {
+    /// Additional classes applied to the dual list selector pane.
+    #[prop_or_default]
+    pub class: Classes,
+
     /// Options to list in the pane.
     #[prop_or_default]
     pub options: Vec<T>,
@@ -42,7 +46,7 @@ pub struct DualListSelectorPaneProps<T: DualListSelectorItemRenderer> {
 
 #[function_component(DualListSelectorPane)]
 pub fn pane<T: DualListSelectorItemRenderer>(props: &DualListSelectorPaneProps<T>) -> Html {
-    let mut class = classes!["pf-v5-c-dual-list-selector__pane"];
+    let mut class = classes!["pf-v5-c-dual-list-selector__pane", props.class.clone()];
     if props.is_chosen {
         class.push("pf-m-chosen")
     } else {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -23,6 +23,7 @@ pub mod divider;
 pub mod dl;
 pub mod drawer;
 pub mod dropdown;
+pub mod dual_list_selector;
 pub mod empty;
 pub mod expandable_section;
 pub mod file_upload;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -23,7 +23,6 @@ pub mod divider;
 pub mod dl;
 pub mod drawer;
 pub mod dropdown;
-pub mod dual_list_selector;
 pub mod empty;
 pub mod expandable_section;
 pub mod file_upload;
@@ -57,3 +56,6 @@ pub mod tooltip;
 
 #[cfg(feature = "tree")]
 pub mod tree;
+
+#[cfg(feature = "dual_list_selector")]
+pub mod dual_list_selector;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,6 +27,7 @@ pub use crate::components::divider::*;
 pub use crate::components::dl::*;
 pub use crate::components::drawer::*;
 pub use crate::components::dropdown::*;
+#[cfg(feature = "dual_list_selector")]
 pub use crate::components::dual_list_selector::*;
 pub use crate::components::empty::*;
 pub use crate::components::expandable_section::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,6 +27,7 @@ pub use crate::components::divider::*;
 pub use crate::components::dl::*;
 pub use crate::components::drawer::*;
 pub use crate::components::dropdown::*;
+pub use crate::components::dual_list_selector::*;
 pub use crate::components::empty::*;
 pub use crate::components::expandable_section::*;
 pub use crate::components::file_upload::*;


### PR DESCRIPTION
Implements the [dual list selector](https://www.patternfly.org/components/dual-list-selector/).

## Features

### Props

Currently supported properties:

- disabled
- pane titles
- options
- pane statuses
- onlistchange event

Currently unsupported properties but planned before merge:

- [x] additional classes
- [x] additional custom callbacks for control buttons
- [x] tooltip props
- [x] onoptionselect event

Currently unsupported properties which aren't planned for the merge:

- id
- tree
- onoptioncheck event
- aria
- searchable
- filtering
- dragging
- actions
- keyboard navigation

### Other stuff that needs to be done

- [x] I should document this as experimental and implement a feature gate
- [x] Insert a demo into the quickstart

## Implementation Details

Similar to how the table is currently implemented, I've defined a new trait `DualListSelectorItemRenderer` which has a blanket implementation for types implementing `Debug + Clone + PartialEq + ToHtml + 'static`. 
This type is used to render a single entry of a list in each of the two panes (available and chosen) by calling `to_html`.

## Open Questions

~~1. I see anymap is listed as a dependency for the project but it doesn't seem to be used anywhere, is this what I should be using for passing custom props to the tooltips?~~
~~2. Patternfly-react is serving the svg of the arrows in the control column but we are using the fa icon which leads to the icons not being centered properly. Would it be possible to serve the svg instead?~~
3. Are there any further acceptance criteria for this MR that I'm not aware of?