### PR TITLE
relax rules for creating an inner page__main-body div

### DIFF
--- a/src/components/page/section.rs
+++ b/src/components/page/section.rs
@@ -198,13 +198,13 @@ pub fn page_section(props: &PageSectionProperties) -> Html {
 
     html! (
         <section {class} id={&props.id} hidden={props.hidden} style={props.style.clone()}>
-                 if props.r#type == PageSectionType::Default && props.limit_width {
-                    <div class="pf-v5-c-page__main-body">
-                        { props.children.clone() }
-                    </div>
-                } else {
+            if props.limit_width {
+                <div class="pf-v5-c-page__main-body">
                     { props.children.clone() }
-                }
+                </div>
+            } else {
+                { props.children.clone() }
+            }
          </section>
     )
 }


### PR DESCRIPTION
I noticed the padding wasn't correct on the breadcrumb page sections. I checked the patternfly-react implementation and they include the inner div whenever the page section is width limited regardless of page section type: https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Page/PageSection.tsx#L134

This also corrects the behavior the breadcrumbs.