### PR TITLE
Implement SearchInput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,10 @@ router = ["yew-nested-router"]
 # things which go away any minute
 legacy = []
 
-experimental = ["tree", "dual_list_selector"]
+experimental = ["tree", "dual_list_selector", "search_input"]
 tree = []
 dual_list_selector = []
+search_input = []
 
 # Enable FontAwesome regular (FAR) and/or brand (FAB) icons, remember to import the font in your application
 icons-far = []

--- a/src/components/button/mod.rs
+++ b/src/components/button/mod.rs
@@ -128,6 +128,9 @@ pub struct ButtonProperties {
 
     #[prop_or_default]
     pub tabindex: Option<isize>,
+
+    #[prop_or_default]
+    pub r#ref: Option<NodeRef>,
 }
 
 /// Button component
@@ -142,6 +145,7 @@ pub struct ButtonProperties {
 #[function_component(Button)]
 pub fn button(props: &ButtonProperties) -> Html {
     let node_ref = use_node_ref();
+    let node_ref = props.r#ref.as_ref().unwrap_or(&node_ref);
 
     let mut classes: Classes = classes!(
         "pf-v5-c-button",

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -23,6 +23,8 @@ pub mod divider;
 pub mod dl;
 pub mod drawer;
 pub mod dropdown;
+#[cfg(feature = "dual_list_selector")]
+pub mod dual_list_selector;
 pub mod empty;
 pub mod expandable_section;
 pub mod file_upload;
@@ -41,6 +43,8 @@ pub mod pagination;
 pub mod panel;
 pub mod popover;
 pub mod progress;
+#[cfg(feature = "search_input")]
+pub mod search_input;
 pub mod select;
 pub mod skeleton;
 pub mod slider;
@@ -57,6 +61,3 @@ pub mod visible;
 
 #[cfg(feature = "tree")]
 pub mod tree;
-
-#[cfg(feature = "dual_list_selector")]
-pub mod dual_list_selector;

--- a/src/components/search_input/mod.rs
+++ b/src/components/search_input/mod.rs
@@ -1,0 +1,434 @@
+use std::ops::Deref;
+
+use crate::components::badge::Badge;
+use crate::components::button::*;
+use crate::components::input_group::*;
+use crate::components::text_input_group::*;
+use crate::icon::Icon;
+use web_sys::HtmlElement;
+use yew::prelude::*;
+use yew_hooks::use_event_with_window;
+
+/// The number of search results returned. Either a total number of results,
+/// or an index of the current result in relation to total results.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResultsCount {
+    Absolute(usize),
+    /// For an index out of total such as "1/5"
+    Fraction(usize, usize),
+}
+
+impl ToHtml for ResultsCount {
+    fn to_html(&self) -> Html {
+        match self {
+            Self::Absolute(i) => html!(i),
+            Self::Fraction(i, j) => html!(format!("{i}/{j}")),
+        }
+    }
+}
+
+pub enum OnSearchEvent {
+    Mouse(MouseEvent),
+    Keyboard(KeyboardEvent),
+}
+
+impl Deref for OnSearchEvent {
+    type Target = Event;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Mouse(e) => e.deref(),
+            Self::Keyboard(e) => e.deref(),
+        }
+    }
+}
+
+impl From<MouseEvent> for OnSearchEvent {
+    fn from(value: MouseEvent) -> Self {
+        Self::Mouse(value)
+    }
+}
+
+impl From<KeyboardEvent> for OnSearchEvent {
+    fn from(value: KeyboardEvent) -> Self {
+        Self::Keyboard(value)
+    }
+}
+
+/// The main search input component.
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct SearchInputProps {
+    /// An accessible label for the search input.
+    #[prop_or_default]
+    pub aria_label: AttrValue,
+    /// Additional classes added to the search input.
+    #[prop_or_default]
+    pub class: Classes,
+    /// Object that makes the search input expandable/collapsable.
+    #[prop_or_default]
+    pub expandable: Option<SearchInputExpandableProperties>,
+    /// A suggestion for autocompleting
+    #[prop_or_default]
+    pub hint: Option<AttrValue>,
+    /// A reference object to attach to the input box.
+    #[prop_or_default]
+    pub inner_ref: Option<NodeRef>,
+    /// Flag indicating if searchinput is disabled.
+    #[prop_or_default]
+    pub disabled: bool,
+    /// Placeholder text of the search input.
+    #[prop_or_default]
+    pub placeholder: Option<AttrValue>,
+    /// Label for the button which resets the advanced search form and clears the search input.
+    #[prop_or(AttrValue::from("Reset"))]
+    pub reset_button_label: AttrValue,
+    /// Label for the button which calls the onSearch event handler.
+    #[prop_or(AttrValue::from("Search"))]
+    pub submit_search_button_label: AttrValue,
+    /// Flag to indicate utilities should be displayed.
+    /// By default, utilities will only be displayed when the search input has a value.
+    #[prop_or_default]
+    pub utilities_displayed: bool,
+    /// Value of the search input.
+    #[prop_or_default]
+    pub value: String,
+
+    // Navigatable results
+    /// The number of search results returned. View `[ResultsCount]`.
+    #[prop_or_default]
+    pub results_count: Option<ResultsCount>,
+    /// Accessible label for the button to navigate to previous result.
+    #[prop_or(AttrValue::from("Previous"))]
+    pub previous_navigation_button_aria_label: AttrValue,
+    /// Flag indicating if the previous navigation button is disabled.
+    #[prop_or_default]
+    pub previous_navigation_button_disabled: bool,
+    /// Accessible label for the button to navigate to next result.
+    #[prop_or(AttrValue::from("Next"))]
+    pub next_navigation_button_aria_label: AttrValue,
+    /// Flag indicating if the next navigation button is disabled.
+    #[prop_or_default]
+    pub next_navigation_button_disabled: bool,
+
+    // Callbacks
+    /// A callback for when the input value changes.
+    #[prop_or_default]
+    pub onchange: Option<Callback<String>>,
+    /// A callback for when the user clicks the clear button.
+    #[prop_or_default]
+    pub onclear: Option<Callback<MouseEvent>>,
+    /// A callback for when the user clicks to navigate to next result.
+    #[prop_or_default]
+    pub onnextclick: Option<Callback<MouseEvent>>,
+    /// A callback for when the user clicks to navigate to previous result.
+    #[prop_or_default]
+    pub onpreviousclick: Option<Callback<MouseEvent>>,
+    /// A callback for when the search button is clicked.
+    #[prop_or_default]
+    pub onsearch: Option<Callback<(OnSearchEvent, String)>>,
+}
+
+/// Properties for creating an expandable search input. These properties should be passed into
+/// the search input component's expandableInput property.
+///
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct SearchInputExpandableProperties {
+    /// Flag to indicate if the search input is expanded.
+    #[prop_or_default]
+    pub expanded: bool,
+    /// Callback function to toggle the expandable search input.
+    #[prop_or_default]
+    pub ontoggleexpand: Callback<(MouseEvent, bool)>,
+    /// An accessible label for the expandable search input toggle.
+    #[prop_or_default]
+    pub toggle_aria_label: AttrValue,
+}
+
+#[function_component(SearchInput)]
+pub fn search_input(props: &SearchInputProps) -> Html {
+    let search_value = use_state(|| props.value.clone());
+    let focus_after_expand_change = use_state(|| false);
+    let is_search_menu_open = use_state(|| false);
+    let node_ref = use_node_ref();
+    let input_ref = props.inner_ref.clone().unwrap_or(node_ref);
+    let expandable_toggle_ref = use_node_ref();
+
+    use_effect_with(
+        (
+            focus_after_expand_change.clone(),
+            props.expandable.clone(),
+            input_ref.clone(),
+            expandable_toggle_ref.clone(),
+        ),
+        |(focus, expandable, input_ref, toggle_ref)| {
+            if !**focus {
+                return;
+            }
+            if expandable.as_ref().is_some_and(|e| e.expanded) {
+                input_ref.cast::<HtmlElement>().map(|e| e.focus());
+            } else {
+                toggle_ref.cast::<HtmlElement>().map(|e| e.focus());
+            }
+        },
+    );
+
+    let ontoggle = {
+        let is_search_menu_open = is_search_menu_open.clone();
+        Callback::from(move |_| {
+            is_search_menu_open.set(!*is_search_menu_open);
+        })
+    };
+    let expand_toggle = if let Some(expandable) = &props.expandable {
+        let onclick = {
+            let value = search_value.clone();
+            let ontoggleexpand = expandable.ontoggleexpand.clone();
+            let focus_after_expand_change = focus_after_expand_change.clone();
+            let expanded = expandable.expanded;
+            Callback::from(move |e| {
+                value.set(String::new());
+                ontoggleexpand.emit((e, expanded));
+                focus_after_expand_change.set(true);
+            })
+        };
+        html! {
+            <Button
+                variant={ButtonVariant::Plain}
+                aria_label={expandable.toggle_aria_label.clone()}
+                aria_expanded={expandable.expanded.to_string()}
+                icon={if expandable.expanded { Icon::Times} else { Icon::Search }}
+                {onclick}
+            />
+        }
+    } else {
+        html! {}
+    };
+    if let Some(SearchInputExpandableProperties {
+        expanded: false, ..
+    }) = props.expandable
+    {
+        html! {
+            <InputGroup class={props.class.clone()}>
+                <InputGroupItem>{expand_toggle}</InputGroupItem>
+            </InputGroup>
+        }
+    } else if props.onsearch.is_some() {
+        html! {
+            <TextInputGroupWithExtraButtons
+                search_value={search_value.clone()}
+                focus_after_expand_change={focus_after_expand_change.clone()}
+                is_search_menu_open={is_search_menu_open.clone()}
+                ontoggle={ontoggle.clone()}
+                expand_toggle={expand_toggle.clone()}
+                {input_ref}
+                props={props.clone()}
+            />
+        }
+    } else if props.expandable.is_some() {
+        html! {
+            <ExpandableInputGroup
+                search_value={search_value.clone()}
+                expand_toggle={expand_toggle.clone()}
+                {input_ref}
+                props={props.clone()}
+            />
+        }
+    } else {
+        html! {
+            <InnerTextInputGroup
+                search_value={search_value.clone()}
+                {input_ref}
+                props={props.clone()}
+            />
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Properties)]
+struct ExpandableInputGroupProps {
+    search_value: UseStateHandle<String>,
+    expand_toggle: Html,
+    input_ref: NodeRef,
+    props: SearchInputProps,
+}
+
+#[function_component(ExpandableInputGroup)]
+fn expandable_input_group(props: &ExpandableInputGroupProps) -> Html {
+    html! {
+        <InputGroup class={props.props.class.clone()}>
+            <InputGroupItem fill=true>
+                <InnerTextInputGroup
+                    props={props.props.clone()}
+                    search_value={props.search_value.clone()}
+                    input_ref={props.input_ref.clone()}
+                />
+            </InputGroupItem>
+            <InputGroupItem plain=true>{props.expand_toggle.clone()}</InputGroupItem>
+        </InputGroup>
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Properties)]
+struct InnerTextInputGroupProps {
+    search_value: UseStateHandle<String>,
+    input_ref: NodeRef,
+    props: SearchInputProps,
+}
+
+#[function_component(InnerTextInputGroup)]
+fn inner_text_input_group(props: &InnerTextInputGroupProps) -> Html {
+    let onchange = {
+        let search_value = props.search_value.clone();
+        let onchange = props.props.onchange.clone();
+        Callback::from(move |value: String| {
+            onchange.as_ref().map(|f| f.emit(value.clone()));
+            search_value.set(value)
+        })
+    };
+    let render_utilities = !props.props.value.is_empty()
+        && (props.props.results_count.is_some()
+            || (props.props.onnextclick.is_some() && props.props.onpreviousclick.is_some())
+            || (props.props.onclear.is_some() && props.props.expandable.is_none()));
+    let badge = if let Some(results_count) = &props.props.results_count {
+        html! { <Badge read=true>{results_count}</Badge> }
+    } else {
+        html! {}
+    };
+
+    let mut clicknav = html! {};
+    if let Some(onnextclick) = &props.props.onnextclick {
+        if let Some(onprevclick) = &props.props.onpreviousclick {
+            clicknav = html! {
+                <div class={classes!["pf-v5-c-text-input-group__group"]}>
+                    <Button
+                        variant={ButtonVariant::Plain}
+                        aria_label={props.props.previous_navigation_button_aria_label.clone()}
+                        disabled={props.props.disabled || props.props.previous_navigation_button_disabled.clone()}
+                        onclick={onprevclick}
+                    >
+                        {Icon::AngleUp}
+                    </Button>
+                    <Button
+                        variant={ButtonVariant::Plain}
+                        aria_label={props.props.next_navigation_button_aria_label.clone()}
+                        disabled={props.props.disabled || props.props.next_navigation_button_disabled}
+                        onclick={onnextclick.clone()}
+                    >
+                        {Icon::AngleDown}
+                    </Button>
+                </div>
+            };
+        }
+    }
+    let onclearinput = {
+        let onclear = props.props.onclear.clone();
+        let input_ref = props.input_ref.clone();
+        Callback::from(move |e| {
+            onclear.as_ref().map(|f| f.emit(e));
+            input_ref.cast::<HtmlElement>().map(|e| e.focus());
+        })
+    };
+    let mut clearnav = html! {};
+    if props.props.onclear.is_some() {
+        if props.props.expandable.is_none() {
+            clearnav = html! {
+                <Button
+                    variant={ButtonVariant::Plain}
+                    disabled={props.props.disabled}
+                    aria_label={props.props.reset_button_label.clone()}
+                    onclick={onclearinput}
+                    r#ref={props.input_ref.clone()}
+                >
+                    {Icon::Times}
+                </Button>
+            };
+        }
+    };
+    html! {
+        <TextInputGroup class={props.props.class.clone()} disabled={props.props.disabled}>
+            <TextInputGroupMain
+                hint={props.props.hint.clone()}
+                icon={Icon::Search}
+                value={(*props.search_value).clone()}
+                placeholder={props.props.placeholder.clone()}
+                aria_label={props.props.aria_label.clone()}
+                {onchange}
+                inner_ref={props.input_ref.clone()}
+            />
+            if render_utilities || props.props.utilities_displayed {
+                <TextInputGroupUtilities>
+                    {badge}
+                    {clicknav}
+                    {clearnav}
+                </TextInputGroupUtilities>
+            }
+        </TextInputGroup>
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Properties)]
+struct TextInputGroupWithExtraButtonsProps {
+    search_value: UseStateHandle<String>,
+    focus_after_expand_change: UseStateHandle<bool>,
+    is_search_menu_open: UseStateHandle<bool>,
+    input_ref: NodeRef,
+    ontoggle: Callback<MouseEvent>,
+    expand_toggle: Html,
+    props: SearchInputProps,
+}
+
+#[function_component(TextInputGroupWithExtraButtons)]
+fn text_input_group_with_extra_buttons(props: &TextInputGroupWithExtraButtonsProps) -> Html {
+    let onsearchhandler = {
+        let onsearch = props.props.onsearch.clone();
+        let value = props.props.value.clone();
+        let is_search_menu_open = props.is_search_menu_open.clone();
+        Callback::from(move |e: OnSearchEvent| {
+            e.prevent_default();
+            onsearch.as_ref().map(|f| f.emit((e, value.clone())));
+            is_search_menu_open.set(false);
+        })
+    };
+    {
+        let onsearchhandler = onsearchhandler.clone();
+        use_event_with_window("keydown", move |e: KeyboardEvent| {
+            if e.key() == "Enter" {
+                onsearchhandler.emit(e.into());
+            }
+        });
+    }
+
+    let submit_button = if props.props.onsearch.is_some() {
+        let onsearchhandler = onsearchhandler.clone();
+        let onclick = Callback::from(move |e: MouseEvent| onsearchhandler.emit(e.into()));
+        html! {
+            <InputGroupItem>
+                <Button
+                    r#type={ButtonType::Submit}
+                    variant={ButtonVariant::Control}
+                    aria_label={props.props.submit_search_button_label.clone()}
+                    {onclick}
+                    disabled={props.props.disabled}
+                >
+                    {Icon::ArrowRight}
+                </Button>
+            </InputGroupItem>
+        }
+    } else {
+        html! {}
+    };
+    html! {
+        <InputGroup class={props.props.class.clone()}>
+            <InputGroupItem fill=true>
+                <InnerTextInputGroup
+                    props={props.props.clone()}
+                    search_value={props.search_value.clone()}
+                    input_ref={props.input_ref.clone()}
+                />
+                {submit_button}
+            </InputGroupItem>
+            if props.props.expandable.is_some() {
+                {props.expand_toggle.clone()}
+            }
+        </InputGroup>
+    }
+}

--- a/src/components/text_input_group.rs
+++ b/src/components/text_input_group.rs
@@ -96,6 +96,12 @@ pub struct TextInputGroupMainProperties {
 
     #[prop_or_default]
     pub autofocus: bool,
+
+    #[prop_or_default]
+    pub inner_ref: Option<NodeRef>,
+
+    #[prop_or_default]
+    pub hint: Option<AttrValue>,
 }
 
 #[function_component(TextInputGroupMain)]
@@ -108,6 +114,7 @@ pub fn text_input_group_main(props: &TextInputGroupMainProperties) -> Html {
     }
 
     let node_ref = use_node_ref();
+    let node_ref = props.inner_ref.as_ref().unwrap_or(&node_ref);
     let oninput = use_on_text_change(
         node_ref.clone(),
         props.oninput.clone(),
@@ -134,6 +141,15 @@ pub fn text_input_group_main(props: &TextInputGroupMainProperties) -> Html {
             style={&props.style}
         >
             <span class="pf-v5-c-text-input-group__text">
+                if let Some(hint) = &props.hint {
+                    <input
+                        class="pf-v5-c-text-input-group__text-input pf-m-hint"
+                        type="text"
+                        disabled=true
+                        aria-hidden="true"
+                        value={hint}
+                    />
+                }
                 if let Some(icon) = &props.icon {
                     <span class="pf-v5-c-text-input-group__icon">
                         { icon.clone() }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -47,6 +47,8 @@ pub use crate::components::pagination::*;
 pub use crate::components::panel::*;
 pub use crate::components::popover::*;
 pub use crate::components::progress::*;
+#[cfg(feature = "search_input")]
+pub use crate::components::search_input::*;
 pub use crate::components::select::*;
 pub use crate::components::skeleton::*;
 pub use crate::components::slider::*;


### PR DESCRIPTION
Implements the [search input](https://www.patternfly.org/components/search-input/) component without the advanced configuration.

Demos can be found (and later merged) here: https://github.com/adogcalledspot/patternfly-yew-quickstart/tree/search_input