### PR TITLE
feat(validation): hide the form hint if the message is none

### DIFF
--- a/src/components/form/validation.rs
+++ b/src/components/form/validation.rs
@@ -61,7 +61,7 @@ pub struct ValidationResult {
 
 impl From<ValidationResult> for Option<FormHelperText> {
     fn from(result: ValidationResult) -> Self {
-        if matches!(result.state, InputState::Default) && result.message.is_none() {
+        if matches!(result.state, InputState::Default) || result.message.is_none() {
             // default state and no message
             None
         } else {


### PR DESCRIPTION
The current implementation always shows the hint if the InputState is non-default.

However, especially on correct input, there might not be anything more to say and you would only want to set the InputState of the input.

Using `message: Some("")` and `message: None` both currently look like this:

![image](https://github.com/patternfly-yew/patternfly-yew/assets/22723953/c45c7e14-4f1b-48ea-a9ed-76ba420634a5)

With the suggested changes, you could distinguish between the two. `Some("")` would still look as above but `None` would look like this:

![image](https://github.com/patternfly-yew/patternfly-yew/assets/22723953/a649b183-cc56-44f2-9b81-85db31a84e49)
