### PR TITLE
feat(SimpleList): Add SimpleList component

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -45,6 +45,7 @@ pub mod popover;
 pub mod progress;
 pub mod search_input;
 pub mod select;
+pub mod simple_list;
 pub mod skeleton;
 pub mod slider;
 pub mod spinner;

--- a/src/components/simple_list.rs
+++ b/src/components/simple_list.rs
@@ -1,0 +1,135 @@
+use crate::prelude::ButtonType;
+use yew::prelude::*;
+
+/// Component for selecting an item out of a list.
+/// Does not support grouping.
+/// If you are looking for a grouped version then use
+/// [`SimpleListGrouped`].
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct SimpleListProperties {
+    /// The items from which can be selected.
+    #[prop_or_default]
+    pub children: ChildrenWithProps<SimpleListItem>,
+    /// Additional classes to add to the list.
+    #[prop_or_default]
+    pub class: Classes,
+}
+
+#[function_component(SimpleList)]
+pub fn simple_list(props: &SimpleListProperties) -> Html {
+    html! {
+        <SimpleListInner class={props.class.clone()}>
+            <ul class={"pf-v5-c-simple-list__list"} role="list">
+                { for props.children.iter() }
+            </ul>
+        </SimpleListInner>
+    }
+}
+
+/// Component for selecting an item out of groups of lists.
+/// If you are looking for a non-grouped version then use
+/// [`SimpleList`].
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct SimpleListGroupedProperties {
+    /// The groups (which contain their items) from which can be selected.
+    #[prop_or_default]
+    pub children: ChildrenWithProps<SimpleListGroup>,
+    /// Additional classes to add to the list.
+    #[prop_or_default]
+    pub class: Classes,
+}
+
+#[function_component(SimpleListGrouped)]
+pub fn simple_list_grouped(props: &SimpleListGroupedProperties) -> Html {
+    html! {
+        <SimpleListInner class={props.class.clone()}>
+            {for props.children.iter()}
+        </SimpleListInner>
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Properties)]
+struct SimpleListInnerProperties {
+    #[prop_or_default]
+    children: Html,
+    #[prop_or_default]
+    class: Classes,
+}
+
+#[function_component(SimpleListInner)]
+fn simple_list_inner(props: &SimpleListInnerProperties) -> Html {
+    let class = classes!("pf-v5-c-simple-list", props.class.clone());
+    html! {
+        <div {class}>{props.children.clone()}</div>
+    }
+}
+
+/// A single item which can be selected in a [`SimpleList`].
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct SimpleListItemProperties {
+    /// The content to be rendered inside the item.
+    #[prop_or_default]
+    pub children: Html,
+    /// Additional classes to pass to the item.
+    #[prop_or_default]
+    pub class: Classes,
+    /// Additional classes to pass to the underlying button.
+    #[prop_or_default]
+    pub button_class: Classes,
+    /// Whether the item is currently selected or not.
+    #[prop_or_default]
+    pub active: bool,
+    /// Callback that is triggered when this item is clicked.
+    #[prop_or_default]
+    pub onclick: Callback<MouseEvent>,
+    /// Type of the underlying button.
+    #[prop_or_default]
+    pub r#type: ButtonType,
+}
+
+#[function_component(SimpleListItem)]
+pub fn simple_list_item(props: &SimpleListItemProperties) -> Html {
+    let class = classes!(props.class.clone(), "pf-v5-c-simple-list__item");
+    let mut button_class = classes!(props.button_class.clone(), "pf-v5-c-simple-list__item-link");
+    if props.active {
+        button_class.push("pf-m-current");
+    }
+    html! {
+        <li {class}>
+            <button class={button_class} onclick={props.onclick.clone()} type="button">
+                {props.children.clone()}
+            </button>
+        </li>
+    }
+}
+
+/// A group organizing [`SimpleListItem`]s in a [`SimpleListGrouped`].
+#[derive(Debug, Clone, PartialEq, Properties)]
+pub struct SimpleListGroupProperties {
+    /// The items that are part of this group.
+    #[prop_or_default]
+    pub children: ChildrenWithProps<SimpleListItem>,
+    /// Additional classes to pass to the group.
+    #[prop_or_default]
+    pub class: Classes,
+    /// Additional classes to pass to the title.
+    #[prop_or_default]
+    pub title_class: Classes,
+    /// The title of the group.
+    #[prop_or_default]
+    pub title: Html,
+}
+
+#[function_component(SimpleListGroup)]
+pub fn simple_list_group(props: &SimpleListGroupProperties) -> Html {
+    let title_class = classes!(props.title_class.clone(), "pf-v5-c-simple-list__title");
+    let class = classes!(props.class.clone(), "pf-v5-c-simple-list__list");
+    html! {
+        <section class="pf-v5-c-simple-list__section">
+            <h2 class={title_class}>{props.title.clone()}</h2>
+            <ul {class} role="list">
+                {for props.children.iter()}
+            </ul>
+        </section>
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -49,6 +49,7 @@ pub use crate::components::popover::*;
 pub use crate::components::progress::*;
 pub use crate::components::search_input::*;
 pub use crate::components::select::*;
+pub use crate::components::simple_list::*;
 pub use crate::components::skeleton::*;
 pub use crate::components::slider::*;
 pub use crate::components::spinner::*;


### PR DESCRIPTION
This adds the SimpleList component.

There is some discussion to be had about the interfaces.

The SimpleList is either grouped or not, never both.
If it is grouped, it needs `SimpleListGroup`s at the top level.
If it isn't grouped then it needs `SimpleListItem`s at the top level.

There are also differences in the content, so I split the two up into separate components to try and enforce some rules.

Due to state management having to occur outside of the component, the user will probably want to abstract the `SimpleListItem`:

```rust

#[function_component(Application)]
fn create_bucket() -> Html {
    let selected = use_state(|| 0);
    let onclick =  use_callback(selected.clone(), |id, selected| {
        log::info!("Setting to {id}");
        selected.set(id)
    });
    html!  {
        <SimpleList>
            <Item id=0 onclick={onclick.clone()} active={*selected == 0}>{"List item 1"}</Item>
            <Item id=1 onclick={onclick.clone()} active={*selected == 1}>{"List item 2"}</Item>
            <Item id=2 onclick={onclick.clone()} active={*selected == 2}>{"List item 3"}</Item>
            <Item id=3 onclick={onclick.clone()} active={*selected == 3}>{"List item 4"}</Item>
        </SimpleList>
    }
}

#[derive(Debug, Clone, PartialEq, Properties)]
pub struct ItemProperties {
    id: u32,
    onclick: Callback<u32>,
    children: Html,
    active: bool,
}

#[function_component(Item)]
pub fn item(props: &ItemProperties) -> Html {
    let onclick = use_callback((props.id, props.onclick.clone()),  move |_, (id, onclick)| onclick.emit(*id));
    html! {
        <SimpleListItem {onclick} active={props.active}>{props.children.clone()}</SimpleListItem>
    }
}
```

Due to this, I'm not happy with using a `ChildrenWithProps`/`ChildrenRenderer` here.
Ideally you would do something like `ChildrenWithProps<T: Into<SimpleListItem>>` but implementing that is really messy.

For the grouped variant, the top level needs to be `SimpleListGroup` which doesn't really do much so using a `ChildrenWithProps` is fine there.

This makes the interfaces between the grouped variant and the ungrouped variant inconsistent.

Open to hearing some suggestions.

TODOs:

- [ ] documentation
