### PR TITLE
refactor: rename additional_class to class

### DIFF
--- a/src/components/card/mod.rs
+++ b/src/components/card/mod.rs
@@ -41,7 +41,7 @@ pub struct CardProperties {
     pub id: AttrValue,
     /// Additional classes added to the card.
     #[prop_or_default]
-    pub additional_class: Classes,
+    pub class: Classes,
     /// Sets the base component to render. Defaults to "div".
     #[prop_or(String::from("div"))]
     pub component: String,
@@ -186,7 +186,7 @@ pub fn card(props: &CardProperties) -> Html {
             class.push("pf-m-selected");
         }
     }
-    class.extend(props.additional_class.clone());
+    class.extend(props.class.clone());
 
     let context = CardContext {
         card_id: props.id.clone(),

--- a/src/components/menu/item.rs
+++ b/src/components/menu/item.rs
@@ -12,7 +12,7 @@ struct MenuItemProperties {
     pub r#type: MenuItemType,
     pub description: Option<String>,
     pub style: Option<AttrValue>,
-    pub additional_class: Classes,
+    pub class: Classes,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -78,7 +78,7 @@ fn menu_item(props: &MenuItemProperties) -> Html {
         }
     };
 
-    class.extend(&props.additional_class);
+    class.extend(&props.class);
 
     html!(
         <li {class} style={&props.style}>
@@ -134,7 +134,7 @@ pub struct MenuActionProperties {
     pub style: Option<AttrValue>,
 
     #[prop_or_default]
-    pub additional_class: Classes,
+    pub class: Classes,
 }
 
 #[function_component(MenuAction)]
@@ -150,7 +150,7 @@ pub fn menu_action(props: &MenuActionProperties) -> Html {
         description,
         selected,
         style,
-        additional_class,
+        class,
     } = props.clone();
 
     let props = MenuItemProperties {
@@ -162,7 +162,7 @@ pub fn menu_action(props: &MenuActionProperties) -> Html {
         description,
         selected,
         style,
-        additional_class,
+        class,
     };
 
     html!(<MenuItem ..props />)
@@ -197,7 +197,7 @@ pub struct MenuLinkProperties {
     pub style: Option<AttrValue>,
 
     #[prop_or_default]
-    pub additional_class: Classes,
+    pub class: Classes,
 }
 
 #[function_component(MenuLink)]
@@ -214,7 +214,7 @@ pub fn menu_link(props: &MenuLinkProperties) -> Html {
         description,
         selected,
         style,
-        additional_class,
+        class,
     } = props.clone();
 
     let props = MenuItemProperties {
@@ -226,7 +226,7 @@ pub fn menu_link(props: &MenuLinkProperties) -> Html {
         description,
         selected,
         style,
-        additional_class,
+        class,
     };
 
     html!(<MenuItem ..props />)

--- a/src/components/progress.rs
+++ b/src/components/progress.rs
@@ -143,7 +143,7 @@ pub struct ProgressProperties {
 
     /// Additional classes for the main element.
     #[prop_or_default]
-    pub additional_class: Classes,
+    pub class: Classes,
 
     /// Additional CSS style
     #[prop_or_default]
@@ -181,7 +181,7 @@ pub fn progress(props: &ProgressProperties) -> Html {
     if props.description.is_none() {
         class.extend(classes!("pf-m-single"));
     }
-    class.extend(&props.additional_class);
+    class.extend(&props.class);
 
     let mut measure = match props.location {
         ProgressMeasureLocation::None => None,

--- a/src/components/toolbar/group.rs
+++ b/src/components/toolbar/group.rs
@@ -36,7 +36,7 @@ pub struct ToolbarGroupProperties {
 
     /// Additional classes
     #[prop_or_default]
-    pub additional_class: Classes,
+    pub class: Classes,
 }
 
 /// A group item for a toolbar
@@ -46,7 +46,7 @@ pub fn toolbar_group(props: &ToolbarGroupProperties) -> Html {
 
     class.extend_from(&props.modifiers);
     class.extend_from(&props.variant);
-    class.extend(props.additional_class.clone());
+    class.extend(props.class.clone());
 
     html! {
         <div

--- a/src/components/toolbar/item.rs
+++ b/src/components/toolbar/item.rs
@@ -55,7 +55,7 @@ pub struct ToolbarItemProperties {
 
     /// Additional classes
     #[prop_or_default]
-    pub additional_class: Classes,
+    pub class: Classes,
 }
 
 #[function_component(ToolbarItem)]
@@ -64,7 +64,7 @@ pub fn toolbar_item(props: &ToolbarItemProperties) -> Html {
 
     class.extend_from(&props.r#type);
     class.extend_from(&props.modifiers);
-    class.extend(props.additional_class.clone());
+    class.extend(props.class.clone());
 
     let style = props
         .width


### PR DESCRIPTION
It's called "class" pretty much everywhere else so using "additional_class" seems inconsistent.

