### PR TITLE
feat(Table): Clickable rows

### DIFF
--- a/src/components/table/model/memoized.rs
+++ b/src/components/table/model/memoized.rs
@@ -37,7 +37,7 @@ impl<T> PartialEq for MemoizedTableModel<T> {
 impl<C, T> super::TableDataModel<C> for MemoizedTableModel<T>
 where
     C: Clone + Eq + 'static,
-    T: TableEntryRenderer<C> + 'static,
+    T: TableEntryRenderer<C> + Clone + 'static,
 {
     type Iterator<'i> = Enumerate<core::slice::Iter<'i, Self::Item>>;
     type Item = T;

--- a/src/components/table/model/mod.rs
+++ b/src/components/table/model/mod.rs
@@ -21,7 +21,7 @@ where
     type Iterator<'i>: Iterator<Item = TableModelEntry<'i, Self::Item, Self::Key, C>>
     where
         Self: 'i;
-    type Item: TableEntryRenderer<C> + 'static;
+    type Item: TableEntryRenderer<C> + Clone + 'static;
     type Key: Into<Key> + Clone + Debug + Eq + 'static;
 
     /// Get the number of items
@@ -65,7 +65,7 @@ where
     type Iterator<'i>: Iterator<Item = (Self::Key, &'i Self::Item)>
     where
         Self: 'i;
-    type Item: TableEntryRenderer<C> + 'static;
+    type Item: TableEntryRenderer<C> + Clone + 'static;
     type Key: Into<Key> + Clone + Debug + Eq + 'static;
 
     /// Get the number of items

--- a/src/components/table/model/state.rs
+++ b/src/components/table/model/state.rs
@@ -41,7 +41,7 @@ where
 impl<C, T> super::TableDataModel<C> for UseStateTableModel<T>
 where
     C: Clone + Eq + 'static,
-    T: PartialEq + TableEntryRenderer<C> + 'static,
+    T: PartialEq + TableEntryRenderer<C> + Clone + 'static,
 {
     type Iterator<'i> = Enumerate<core::slice::Iter<'i, Self::Item>>;
     type Item = T;


### PR DESCRIPTION
Adds two callbacks which both pass in the `Item` which is shown by the row in the table:

- One for adding an onclick handler
- One for deciding whether the row is selected.

## Notes

For some reason the compiler can't handle the type signature of `Callback<M::Item>` and keeps complaining that it can't compare `<M as TableModel<C>>::Item` with `<M a TableModel<C>>::Item` even though it doesn't have to.
Saying `Callback<M as TableModel<C>>::Item>` fixes this.

Since the callback argument needs to be cloned into the callback, this adds a `Clone` trait bound on table data which I don't see as much of an issue.