### PR TITLE
Some fixes

### DIFF
--- a/src/components/table/mod.rs
+++ b/src/components/table/mod.rs
@@ -200,12 +200,12 @@ where
     );
 
     let expandable = props.is_expandable() && !props.are_columns_expandable();
-    html! (
+    html!(
         <ComposableTable
             id={&props.id}
             class={props.class.clone()}
             sticky_header={props.header.as_ref().is_some_and(|header| header.props.sticky)}
-            mode={props.mode.clone()}
+            mode={props.mode}
             borders={props.borders}
             grid={props.grid}
             ouia_id={props.ouia_id.clone()}
@@ -322,7 +322,7 @@ where
     }
 
     if cols > 0 {
-        cells.push(html! (
+        cells.push(html!(
             <TableData colspan={cols}/>
         ));
     }
@@ -335,7 +335,7 @@ where
             .reform(move |_| (key.clone(), ExpansionState::Row))
     };
 
-    html! (
+    html!(
         <TableBody {key} {expanded}>
             <TableRow control_row={!expandable_columns.is_empty() && props.mode.is_expandable()}>
                 // first column, the toggle

--- a/src/components/tabs/simple.rs
+++ b/src/components/tabs/simple.rs
@@ -59,6 +59,16 @@ where
     /// OUIA Component Safe
     #[prop_or(OuiaSafe::TRUE)]
     pub ouia_safe: OuiaSafe,
+
+    /// OUIA Component id
+    #[prop_or_default]
+    pub scroll_button_ouia_id: Option<String>,
+    /// OUIA Component Type
+    #[prop_or(OUIA_BUTTON.component_type())]
+    pub scroll_button_ouia_type: OuiaComponentType,
+    /// OUIA Component Safe
+    #[prop_or(OuiaSafe::TRUE)]
+    pub scroll_button_ouia_safe: OuiaSafe,
 }
 
 /// Tabs component
@@ -130,7 +140,11 @@ where
         selected: props.selected.clone(),
     };
 
-    html! (
+    let button_ouia_id = use_memo(props.scroll_button_ouia_id.clone(), |id| {
+        id.clone().unwrap_or(OUIA.generated_id())
+    });
+
+    html!(
         <ContextProvider<TabsContext<T>> {context}>
             <div
                 {class}
@@ -144,9 +158,9 @@ where
                     disabled=true
                     aria-hidden="true"
                     aria-label="Scroll left"
-                    data-ouia-component-type={OUIA_BUTTON.component_type()}
-                    data-ouia-safe="true"
-                    data-ouia-component-id={OUIA_BUTTON.generated_id()}
+                    data-ouia-component-type={props.scroll_button_ouia_type}
+                    data-ouia-safe={props.scroll_button_ouia_safe}
+                    data-ouia-component-id={(*button_ouia_id).clone()}
                 >
                     { Icon::AngleLeft }
                 </button>
@@ -254,7 +268,7 @@ where
         },
     );
 
-    html! (
+    html!(
         <li
             {class}
             id={props.id.clone()}
@@ -354,7 +368,7 @@ where
         .map(|context| context.selected == props.index)
         .unwrap_or_default();
 
-    html! (
+    html!(
         <TabContent
             hidden={!current}
             id={props.id.clone()}

--- a/src/core/breakpoint.rs
+++ b/src/core/breakpoint.rs
@@ -10,7 +10,7 @@ use yew::prelude::*;
 use yew_more_hooks::prelude::Breakpoint as BreakpointTrait;
 
 /// Breakpoint definitions
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Breakpoint {
     None,
     Small,
@@ -18,12 +18,6 @@ pub enum Breakpoint {
     Large,
     XLarge,
     XXLarge,
-}
-
-impl PartialOrd for Breakpoint {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.as_pixels().partial_cmp(&other.as_pixels())
-    }
 }
 
 impl BreakpointTrait for Breakpoint {


### PR DESCRIPTION
---

fix: prevent re-renders due to ID change

---

fix: use derived ord implementation

This was raised by clippy (1.76.0) as an error and warning.

A custom impl of PartialOrd seems to require a custom impl or Ord too.

Also, the implementation of PartialOrd was warned about. I am also not
if this is necessary, let's have compiler figure this out.