### PR TITLE
refactor: Remove unnecessary single-dependency feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,7 @@ web-sys = { version = "0.3.66", features = [
 
 
 [features]
-default = ["router"]
-router = ["yew-nested-router"]
+default = ["yew-nested-router"]
 
 # things which go away any minute
 legacy = []

--- a/src/components/breadcrumb/mod.rs
+++ b/src/components/breadcrumb/mod.rs
@@ -5,11 +5,11 @@ use crate::utils::{Ouia, OuiaSafe};
 use variant::BreadcrumbItemVariant;
 use yew::{html::ChildrenRenderer, prelude::*};
 
-#[cfg(feature = "router")]
+#[cfg(feature = "yew-nested-router")]
 mod router;
 mod variant;
 
-#[cfg(feature = "router")]
+#[cfg(feature = "yew-nested-router")]
 pub use router::*;
 
 const OUIA: Ouia = ouia!("Breadcrumb");


### PR DESCRIPTION
BREAKING CHANGE: Build will fail for users who explicitly enabled the "router" feature

Having single dependency feature aliased with a different alias is unnecessary. If there is a need to add more dependencies, it's easy to re-add alias with the same name :)