### PR TITLE
Toggle button (bars)  not shown if sidebar is empty

### DIFF
--- a/src/components/page/mod.rs
+++ b/src/components/page/mod.rs
@@ -70,9 +70,9 @@ pub fn page(props: &PageProperties) -> Html {
     html! (
         <div class="pf-v5-c-page" id={&props.id} role="main" tabindex="-1">
             <header class="pf-v5-c-masthead">
-                // If the sidebar is empty then the toggle button is not 
+                // If the sidebar is empty then the toggle button is not
                 // shown
-                if !props.sidebar.clone().is_empty() {
+                if !props.sidebar.is_empty() {
                     <span class="pf-v5-c-masthead__toggle">
                         <Button
                             r#type={ButtonType::Button}

--- a/src/components/page/mod.rs
+++ b/src/components/page/mod.rs
@@ -70,15 +70,19 @@ pub fn page(props: &PageProperties) -> Html {
     html! (
         <div class="pf-v5-c-page" id={&props.id} role="main" tabindex="-1">
             <header class="pf-v5-c-masthead">
-                <span class="pf-v5-c-masthead__toggle">
-                    <Button
-                        r#type={ButtonType::Button}
-                        variant={ButtonVariant::Plain}
-                        {onclick}
-                    >
-                        <i class="fas fa-bars" aria-hidden="true" />
-                    </Button>
-                </span>
+                // If the sidebar is empty then the toggle button is not 
+                // shown
+                if !props.sidebar.clone().is_empty() {
+                    <span class="pf-v5-c-masthead__toggle">
+                        <Button
+                            r#type={ButtonType::Button}
+                            variant={ButtonVariant::Plain}
+                            {onclick}
+                        >
+                            <i class="fas fa-bars" aria-hidden="true" />
+                        </Button>
+                    </span>
+                }
 
                 <div class="pf-v5-c-masthead__main">
                     { props.brand.clone() }


### PR DESCRIPTION
The Page component is slightly modified in a such way that if one decides to make a page without a sidebar (aka Horizontal navigation) then the bars button will not be displayed.