### PR TITLE
fix: Dispatch the autofocus effect on value of autofocus prop

### DIFF
--- a/src/components/form/area.rs
+++ b/src/components/form/area.rs
@@ -183,10 +183,10 @@ pub fn text_area(props: &TextAreaProperties) -> Html {
     // autofocus
 
     {
-        let autofocus = props.autofocus;
-        use_effect_with(input_ref.clone(), move |input_ref| {
-            if autofocus {
-                focus(input_ref)
+        let input_ref = input_ref.clone();
+        use_effect_with(props.autofocus, move |autofocus| {
+            if *autofocus {
+                focus(&input_ref)
             }
         });
     }

--- a/src/components/form/input.rs
+++ b/src/components/form/input.rs
@@ -204,10 +204,10 @@ pub fn text_input(props: &TextInputProperties) -> Html {
     // autofocus
 
     {
-        let autofocus = props.autofocus;
-        use_effect_with(input_ref.clone(), move |input_ref| {
-            if autofocus {
-                focus(input_ref)
+        let input_ref = input_ref.clone();
+        use_effect_with(props.autofocus, move |autofocus| {
+            if *autofocus {
+                focus(&input_ref)
             }
         });
     }

--- a/src/components/text_input_group.rs
+++ b/src/components/text_input_group.rs
@@ -124,10 +124,10 @@ pub fn text_input_group_main(props: &TextInputGroupMainProperties) -> Html {
     // autofocus
 
     {
-        let autofocus = props.autofocus;
-        use_effect_with(node_ref.clone(), move |input_ref| {
-            if autofocus {
-                input_ref.focus();
+        let node_ref = node_ref.clone();
+        use_effect_with(props.autofocus, move |autofocus| {
+            if *autofocus {
+                node_ref.focus();
             }
         });
     }


### PR DESCRIPTION
Previously, the use_effect_with call was invoked with the NodeRef on the respective components' Properties, which works well if user code passes a stable NodeRef in as a prop; if the prop gets defaulted though, that value changes every time through the re-render... which would auto-focus the field everytime an unrelated field in the form changed.

So instead, pass the value of the autofocus prop as an effect condition, and move the input ref the traditional way (via cloning/move closure capture). This ensures that the effect is triggered only once on first render, and then only when the autofocus prop changes.

Refs: #145
Fixes: #145