### PR TITLE
Promote gallery element keys into their wrapper divs

### DIFF
--- a/src/layouts/gallery.rs
+++ b/src/layouts/gallery.rs
@@ -33,9 +33,9 @@ pub fn gallery(props: &GalleryProperties) -> Html {
             class={classes}
             style={&props.style}
         >
-        { for props.children.iter().map(|child|{
+        { for props.children.iter().enumerate().map(|(i, child)|{
             html!{
-                <div class="pf-v5-l-gallery__item">
+                <div key={child.key().map(|k| k.clone()).unwrap_or_else(|| i.into())} class="pf-v5-l-gallery__item">
                     { child.clone() }
                 </div>
             }

--- a/src/layouts/gallery.rs
+++ b/src/layouts/gallery.rs
@@ -1,6 +1,8 @@
 //! Gallery
 
+use crate::prelude::wrap::wrapper_div_with_attributes;
 use yew::prelude::*;
+use yew::virtual_dom::ApplyAttributeAs;
 
 #[derive(Clone, PartialEq, Properties)]
 pub struct GalleryProperties {
@@ -33,12 +35,8 @@ pub fn gallery(props: &GalleryProperties) -> Html {
             class={classes}
             style={&props.style}
         >
-        { for props.children.iter().enumerate().map(|(i, child)|{
-            html!{
-                <div key={child.key().map(|k| k.clone()).unwrap_or_else(|| i.into())} class="pf-v5-l-gallery__item">
-                    { child.clone() }
-                </div>
-            }
+        { for props.children.iter().map(|child|{
+            wrapper_div_with_attributes(child, &[("class", "pf-v5-l-gallery__item", ApplyAttributeAs::Attribute)])
         }) }
         </div>
     )

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,7 @@ mod ouia;
 mod props;
 mod raw;
 mod styled;
+pub(crate) mod wrap;
 
 pub use action::*;
 pub use attr_value::*;

--- a/src/utils/wrap.rs
+++ b/src/utils/wrap.rs
@@ -1,0 +1,15 @@
+use yew::prelude::*;
+use yew::virtual_dom::{ApplyAttributeAs, Attributes, VNode, VTag};
+
+/// Wrap an element in a div with the given class, preserving the
+/// wrapped element's key property.
+pub(crate) fn wrapper_div_with_attributes(
+    child: VNode,
+    attributes: &'static [(&'static str, &'static str, ApplyAttributeAs)],
+) -> Html {
+    let mut div = VTag::new("div");
+    div.key = child.key().map(ToOwned::to_owned);
+    div.attributes = Attributes::Static(attributes);
+    div.add_child(child);
+    VNode::VTag(div.into())
+}


### PR DESCRIPTION
Unless every direct child of the gallery has a key element, every time the set of children changes, *every* child will be re-rendered, which leads to scroll state confusion and bad performance of the gallery.

So, let's promote up the child's `key` if one is set. As the `html!` macro lacks a way to only set a property conditionally (as for optional props like `key`), this requires rewriting the wrapping logic to use the virtual DOM directly.

Fixes #148 