### PR TITLE
Promote keys from all list-like components' child components

### DIFF
--- a/src/components/accordion/mod.rs
+++ b/src/components/accordion/mod.rs
@@ -1,5 +1,8 @@
 //! Accordion
 use yew::prelude::*;
+use yew::virtual_dom::ApplyAttributeAs;
+
+use crate::prelude::wrap::wrapper_div_with_attributes;
 
 #[derive(Clone, Debug, PartialEq, Properties)]
 pub struct AccordionProperties {
@@ -84,11 +87,7 @@ pub fn accordion_item(props: &AccordionItemProperties) -> Html {
                 </button>
             </h3>
             <div class={content_class} hidden={!expanded}>
-                { for props.children.iter().map(|item| html!(
-                    <div class="pf-v5-c-accordion__expandable-content-body">
-                        { item }
-                    </div>
-                )) }
+                { for props.children.iter().map(|item| wrapper_div_with_attributes(item, &[("class", "pf-v5-c-accordion__expandable-content-body", ApplyAttributeAs::Attribute)])) }
             </div>
         </>
     )

--- a/src/components/alert.rs
+++ b/src/components/alert.rs
@@ -1,9 +1,11 @@
 //! Alert popup
 
 use crate::ouia;
+use crate::prelude::wrap::wrapper_elt_with_attributes;
 use crate::prelude::{Action, Button, ButtonVariant, Icon};
 use crate::utils::{Ouia, OuiaComponentType, OuiaSafe};
 use yew::prelude::*;
+use yew::virtual_dom::ApplyAttributeAs;
 
 const OUIA: Ouia = ouia!("Alert");
 
@@ -188,11 +190,9 @@ pub fn view(props: &GroupProperties) -> Html {
 
     html! (
         <ul class={classes} role="list">
-            { for props.children.iter().map(|child|html!{
-                <li class="pf-v5-c-alert-group__item">
-                    { child }
-                </li>
-            })}
+            { for props.children.iter().map(|child|
+                wrapper_elt_with_attributes(child.to_html(), "li", &[("class", "pf-v5-c-alert-group__item", ApplyAttributeAs::Attribute)])
+            )}
         </ul>
     )
 }

--- a/src/components/chip_group.rs
+++ b/src/components/chip_group.rs
@@ -1,7 +1,9 @@
 //! Chip Group
 
+use crate::prelude::wrap::wrapper_elt_with_attributes;
 use crate::prelude::{use_prop_id, Chip};
 use yew::prelude::*;
+use yew::virtual_dom::ApplyAttributeAs;
 
 #[derive(Clone, Debug, PartialEq, Properties)]
 pub struct ChipGroupProperties {
@@ -52,11 +54,7 @@ pub fn chip_group(props: &ChipGroupProperties) -> Html {
                     aria-labelledby={aria_labelled_by}
                 >
                     { for props.children.iter().map(|chip| {
-                        html!(
-                            <li class="pf-v5-c-chip-group__list-item">
-                                { chip }
-                            </li>
-                        )
+                        wrapper_elt_with_attributes(chip.to_html(), "li", &[("class", "pf-v5-c-chip-group__list-item", ApplyAttributeAs::Attribute)])
                     })}
                 </ul>
             </div>

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -1,8 +1,10 @@
 //! Modal
 use crate::ouia;
 use crate::prelude::use_backdrop;
+use crate::prelude::wrap::wrapper_div_with_attributes;
 use crate::utils::{Ouia, OuiaComponentType, OuiaSafe};
 use yew::prelude::*;
+use yew::virtual_dom::ApplyAttributeAs;
 use yew_hooks::{use_click_away, use_event_with_window};
 
 const OUIA: Ouia = ouia!("ModalContent");
@@ -169,9 +171,11 @@ pub fn modal(props: &ModalProperties) -> Html {
             }
 
             { for props.children.iter().map(|c|{
-               { html! (
-                    <div class="pf-v5-c-modal-box__body" id="modal-description">{c}</div>
-               ) }
+                wrapper_div_with_attributes(c,
+                    &[
+                        ("class", "pf-v5-l-gallery__item", ApplyAttributeAs::Attribute),
+                        ("id", "modal-description", ApplyAttributeAs::Attribute)
+                    ])
             }) }
 
             if let Some(footer) = &props.footer {

--- a/src/layouts/bullseye.rs
+++ b/src/layouts/bullseye.rs
@@ -1,5 +1,8 @@
 //! Bullseye
 use yew::prelude::*;
+use yew::virtual_dom::ApplyAttributeAs;
+
+use crate::prelude::wrap::wrapper_div_with_attributes;
 
 #[derive(Clone, PartialEq, Properties)]
 pub struct BullseyeProperties {
@@ -27,9 +30,9 @@ pub fn bullseye(props: &BullseyeProperties) -> Html {
                     // according to the PatternFly documentation wrapping element with the item
                     // shouldn't make a difference. In practice, sometimes it does.
                     c
-                } else {html!{
-                    <div class="pf-v5-l-bullseye__item">{c}</div>
-                }}
+                } else {
+                    wrapper_div_with_attributes(c, &[("class", "pf-v5-l-bullseye__item", ApplyAttributeAs::Attribute)])
+                }
             }) }
         </div>
     }

--- a/src/utils/wrap.rs
+++ b/src/utils/wrap.rs
@@ -1,15 +1,25 @@
 use yew::prelude::*;
 use yew::virtual_dom::{ApplyAttributeAs, Attributes, VNode, VTag};
 
-/// Wrap an element in a div with the given class, preserving the
+/// Wrap an element in another element with the given attributes,
+/// preserving the wrapped element's key property.
+pub(crate) fn wrapper_elt_with_attributes(
+    child: VNode,
+    element_name: &'static str,
+    attributes: &'static [(&'static str, &'static str, ApplyAttributeAs)],
+) -> Html {
+    let mut elt = VTag::new(element_name);
+    elt.key = child.key().map(ToOwned::to_owned);
+    elt.attributes = Attributes::Static(attributes);
+    elt.add_child(child);
+    VNode::VTag(elt.into())
+}
+
+/// Wrap an element in a div with the given attributes, preserving the
 /// wrapped element's key property.
 pub(crate) fn wrapper_div_with_attributes(
     child: VNode,
     attributes: &'static [(&'static str, &'static str, ApplyAttributeAs)],
 ) -> Html {
-    let mut div = VTag::new("div");
-    div.key = child.key().map(ToOwned::to_owned);
-    div.attributes = Attributes::Static(attributes);
-    div.add_child(child);
-    VNode::VTag(div.into())
+    wrapper_elt_with_attributes(child, "div", attributes)
 }


### PR DESCRIPTION
Same as #149, this change pulls all the list-like components' child component key properties up into the elements introduced that wrap the children. This should reduce the need to re-compute child components with larger children or many children (like accordions).