### PR TITLE
Restored padding within modal body

### DIFF
--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -173,7 +173,7 @@ pub fn modal(props: &ModalProperties) -> Html {
             { for props.children.iter().map(|c|{
                 wrapper_div_with_attributes(c,
                     &[
-                        ("class", "pf-v5-l-gallery__item", ApplyAttributeAs::Attribute),
+                        ("class", "pf-v5-c-modal-box__body", ApplyAttributeAs::Attribute),
                         ("id", "modal-description", ApplyAttributeAs::Attribute)
                     ])
             }) }


### PR DESCRIPTION
The class pf-v5-l-gallery__item applied to the body of the modal since v 0.6.1 has been replaced with pf-v5-c-modal-box__body because otherwise the elements have wrong padding.