### PR TITLE
fix, tree table: only mark as expanded if children are hidden

### DIFF
--- a/src/components/tree/mod.rs
+++ b/src/components/tree/mod.rs
@@ -209,11 +209,11 @@ where
 
     let mut class = classes!("pf-v5-c-table__tr");
 
-    if *expanded {
+    let children = props.node.children();
+
+    if *expanded && !children.is_empty() {
         class.extend(classes!("pf-m-expanded"));
     }
-
-    let children = props.node.children();
 
     html!(
         <>


### PR DESCRIPTION
We're setting `pf-m-expanded` for all rows, even for ones with no children. This is inconsistent with https://v5-archive.patternfly.org/components/table/react/tree-table/