### PR TITLE
Update checkbox.rs

### DIFF
--- a/src/components/form/checkbox.rs
+++ b/src/components/form/checkbox.rs
@@ -194,6 +194,7 @@ pub fn checkbox(props: &CheckboxProperties) -> Html {
             <input
                 class={classes!["pf-v6-c-check__input", props.input_class.clone()]}
                 type="checkbox"
+                name={&props.name}
                 {onchange}
                 aria-invalid={props.valid.to_string()}
                 aria-label={props.aria_label.clone()}


### PR DESCRIPTION
Add pass-through of Name prop for checkboxes. The prop was already there, it was just never used.
Verified functionality by compiling and testing in current project. Checkbox inputs now utilize supplied name, and are thus findable by the FormData interface.

Closes https://github.com/patternfly-yew/patternfly-yew/issues/174